### PR TITLE
test: don't use 'network=host' when launching the Tendermint docker image

### DIFF
--- a/tests/helpers/docker/tendermint.py
+++ b/tests/helpers/docker/tendermint.py
@@ -28,7 +28,8 @@ from tests.helpers.docker.base import DockerImage
 
 
 DEFAULT_TENDERMINT_PORT = 26657
-DEFAULT_PROXY_APP = "tcp://0.0.0.0:26658"
+DEFAULT_ABCI_PORT = 26658
+DEFAULT_PROXY_APP = f"tcp://host.docker.internal:{DEFAULT_ABCI_PORT}"
 
 _SLEEP_TIME = 1
 
@@ -60,8 +61,15 @@ class TendermintDockerImage(DockerImage):
     def create(self) -> Container:
         """Create the container."""
         cmd = self._build_command()
+        ports = {
+            f"{DEFAULT_TENDERMINT_PORT}/tcp": ("0.0.0.0", self.port),  # nosec
+        }
         container = self._client.containers.run(
-            self.tag, command=cmd, detach=True, network="host"
+            self.tag,
+            command=cmd,
+            detach=True,
+            ports=ports,
+            extra_hosts={"host.docker.internal": "host-gateway"},
         )
         return container
 


### PR DESCRIPTION
## Proposed changes

Try to solve macOS issues when running experiments that require Docker by not using 'network=host' when launching the Tendermint Docker image.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a