### PR TITLE
fix: don't use network=host in HardHat

### DIFF
--- a/tests/helpers/docker/gnosis_safe_net.py
+++ b/tests/helpers/docker/gnosis_safe_net.py
@@ -76,11 +76,12 @@ class GnosisSafeNetDockerImage(DockerImage):
                 "mode": "rw",
             },
         }
+        ports = {f"{self.port}/tcp": ("0.0.0.0", self.port)}  # nosec
         container = self._client.containers.run(
             self.tag,
             command=cmd,
             detach=True,
-            network="host",
+            ports=ports,
             volumes=volumes,
             working_dir=working_dir,
             entrypoint="yarn",


### PR DESCRIPTION
## Proposed changes

Don't use network=host in HardHat, due to macOS issues.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a