### PR TITLE
test: fix e2e catch-up test

### DIFF
--- a/tests/test_agents/test_price_estimation_abci.py
+++ b/tests/test_agents/test_price_estimation_abci.py
@@ -18,6 +18,8 @@
 # ------------------------------------------------------------------------------
 
 """Integration tests for the valory/price_estimation_abci skill."""
+from enum import Enum
+from operator import itemgetter
 
 from tests.fixture_helpers import UseGnosisSafeHardHatNet
 from tests.test_agents.base import (
@@ -26,61 +28,86 @@ from tests.test_agents.base import (
 )
 
 
+class StringType(Enum):
+    """
+    Type of string to be found in the agent's output.
+
+    BEHAVIOUR: the string is printed by an agent's behaviour
+    ROUND: the string is printed by the ABCI app.
+    """
+
+    BEHAVIOUR = "behaviour"
+    ROUND = "round"
+
+
 # check log messages of the happy path
-CHECK_STRINGS = (
-    "Entered in the 'tendermint_healthcheck' behaviour state",
-    "'tendermint_healthcheck' behaviour state is done",
-    "Entered in the 'registration_startup' round for period 0",
-    "'registration_startup' round is done",
-    "Entered in the 'randomness_safe' round for period 0",
-    "'randomness_safe' round is done",
-    "Entered in the 'select_keeper_safe' round for period 0",
-    "'select_keeper_safe' round is done",
-    "Entered in the 'deploy_safe' round for period 0",
-    "'deploy_safe' round is done",
-    "Entered in the 'validate_safe' round for period 0",
-    "'validate_safe' round is done",
-    "Entered in the 'randomness_oracle' round for period 0",
-    "'randomness_oracle' round is done",
-    "Entered in the 'select_keeper_oracle' round for period 0",
-    "'select_keeper_oracle' round is done",
-    "Entered in the 'deploy_oracle' round for period 0",
-    "'deploy_oracle' round is done",
-    "Entered in the 'validate_oracle' round for period 0",
-    "'validate_oracle' round is done",
-    "Entered in the 'collect_observation' round for period 0",
-    "Got observation of BTC price in USD",
-    "'collect_observation' round is done",
-    "Entered in the 'estimate_consensus' round for period 0",
-    "Got estimate of BTC price in USD:",
-    "'estimate_consensus' round is done",
-    "Entered in the 'tx_hash' round for period 0",
-    "'tx_hash' round is done",
-    "Entered in the 'randomness_transaction_submission' round for period 0",
-    "'randomness_transaction_submission' round is done",
-    "Entered in the 'select_keeper_transaction_submission_a' round for period 0",
-    "'select_keeper_transaction_submission_a' round is done",
-    "Entered in the 'collect_signature' round for period 0",
-    "Signature:",
-    "'collect_signature' round is done",
-    "Entered in the 'finalization' round for period 0",
-    "'finalization' round is done",
-    "Finalized estimate",
-    "Entered in the 'validate_transaction' round for period 0",
-    "'validate_transaction' round is done",
-    "Period end",
-    "Entered in the 'reset_and_pause' round for period 0",
-    "'reset_and_pause' round is done",
-    "Period end",
-    "Entered in the 'collect_observation' round for period 1",
-    "Entered in the 'estimate_consensus' round for period 1",
-    "Entered in the 'tx_hash' round for period 1",
-    "Entered in the 'randomness_transaction_submission' round for period 1",
-    "Entered in the 'select_keeper_transaction_submission_a' round for period 1",
-    "Entered in the 'collect_signature' round for period 1",
-    "Entered in the 'finalization' round for period 1",
-    "Entered in the 'validate_transaction' round for period 1",
-    "Entered in the 'reset_and_pause' round for period 1",
+# fmt: off
+CHECK_STRINGS_LABELLED = [
+    ("Entered in the 'tendermint_healthcheck' behaviour state", StringType.BEHAVIOUR),
+    ("'tendermint_healthcheck' behaviour state is done", StringType.BEHAVIOUR),
+    ("Entered in the 'registration_startup' round for period 0", StringType.ROUND),
+    ("'registration_startup' round is done", StringType.ROUND),
+    ("Entered in the 'randomness_safe' round for period 0", StringType.ROUND),
+    ("'randomness_safe' round is done", StringType.ROUND),
+    ("Entered in the 'select_keeper_safe' round for period 0", StringType.ROUND),
+    ("'select_keeper_safe' round is done", StringType.ROUND),
+    ("Entered in the 'deploy_safe' round for period 0", StringType.ROUND),
+    ("'deploy_safe' round is done", StringType.ROUND),
+    ("Entered in the 'validate_safe' round for period 0", StringType.ROUND),
+    ("'validate_safe' round is done", StringType.ROUND),
+    ("Entered in the 'randomness_oracle' round for period 0", StringType.ROUND),
+    ("'randomness_oracle' round is done", StringType.ROUND),
+    ("Entered in the 'select_keeper_oracle' round for period 0", StringType.ROUND),
+    ("'select_keeper_oracle' round is done", StringType.ROUND),
+    ("Entered in the 'deploy_oracle' round for period 0", StringType.ROUND),
+    ("'deploy_oracle' round is done", StringType.ROUND),
+    ("Entered in the 'validate_oracle' round for period 0", StringType.ROUND),
+    ("'validate_oracle' round is done", StringType.ROUND),
+    ("Entered in the 'collect_observation' round for period 0", StringType.ROUND),
+    ("Got observation of BTC price in USD", StringType.BEHAVIOUR),
+    ("'collect_observation' round is done", StringType.ROUND),
+    ("Entered in the 'estimate_consensus' round for period 0", StringType.ROUND),
+    ("Got estimate of BTC price in USD:", StringType.BEHAVIOUR),
+    ("'estimate_consensus' round is done", StringType.ROUND),
+    ("Entered in the 'tx_hash' round for period 0", StringType.ROUND),
+    ("'tx_hash' round is done", StringType.ROUND),
+    ("Entered in the 'randomness_transaction_submission' round for period 0", StringType.ROUND),
+    ("'randomness_transaction_submission' round is done", StringType.ROUND),
+    ("Entered in the 'select_keeper_transaction_submission_a' round for period 0", StringType.ROUND),
+    ("'select_keeper_transaction_submission_a' round is done", StringType.ROUND),
+    ("Entered in the 'collect_signature' round for period 0", StringType.ROUND),
+    ("Signature:", StringType.BEHAVIOUR),
+    ("'collect_signature' round is done", StringType.ROUND),
+    ("Entered in the 'finalization' round for period 0", StringType.ROUND),
+    ("'finalization' round is done", StringType.ROUND),
+    ("Finalized estimate", StringType.BEHAVIOUR),
+    ("Entered in the 'validate_transaction' round for period 0", StringType.ROUND),
+    ("'validate_transaction' round is done", StringType.ROUND),
+    ("Period end", StringType.BEHAVIOUR),
+    ("Entered in the 'reset_and_pause' round for period 0", StringType.ROUND),
+    ("'reset_and_pause' round is done", StringType.ROUND),
+    ("Period end", StringType.BEHAVIOUR),
+    ("Entered in the 'collect_observation' round for period 1", StringType.ROUND),
+    ("Entered in the 'estimate_consensus' round for period 1", StringType.ROUND),
+    ("Entered in the 'tx_hash' round for period 1", StringType.ROUND),
+    ("Entered in the 'randomness_transaction_submission' round for period 1", StringType.ROUND),
+    ("Entered in the 'select_keeper_transaction_submission_a' round for period 1", StringType.ROUND),
+    ("Entered in the 'collect_signature' round for period 1", StringType.ROUND),
+    ("Entered in the 'finalization' round for period 1", StringType.ROUND),
+    ("Entered in the 'validate_transaction' round for period 1", StringType.ROUND),
+    ("Entered in the 'reset_and_pause' round for period 1", StringType.ROUND),
+]
+# fmt: on
+
+# take all strings
+CHECK_STRINGS_ALL = tuple(map(itemgetter(0), CHECK_STRINGS_LABELLED))
+
+# take only round strings
+CHECK_STRINGS_ONLY_ROUND = tuple(
+    map(
+        itemgetter(0),
+        filter(lambda x: x[1] == StringType.ROUND, CHECK_STRINGS_LABELLED),
+    )
 )
 
 
@@ -94,7 +121,7 @@ class TestABCIPriceEstimationSingleAgent(
     agent_package = "valory/price_estimation:0.1.0"
     skill_package = "valory/price_estimation_abci:0.1.0"
     wait_to_finish = 120
-    check_strings = CHECK_STRINGS
+    check_strings = CHECK_STRINGS_ALL
 
 
 class TestABCIPriceEstimationTwoAgents(
@@ -107,7 +134,7 @@ class TestABCIPriceEstimationTwoAgents(
     agent_package = "valory/price_estimation:0.1.0"
     skill_package = "valory/price_estimation_abci:0.1.0"
     wait_to_finish = 120
-    check_strings = CHECK_STRINGS
+    check_strings = CHECK_STRINGS_ALL
 
 
 class TestABCIPriceEstimationFourAgents(
@@ -120,7 +147,7 @@ class TestABCIPriceEstimationFourAgents(
     agent_package = "valory/price_estimation:0.1.0"
     skill_package = "valory/price_estimation_abci:0.1.0"
     wait_to_finish = 120
-    check_strings = CHECK_STRINGS
+    check_strings = CHECK_STRINGS_ALL
 
 
 class TestAgentCatchup(BaseTestEnd2EndAgentCatchup, UseGnosisSafeHardHatNet):
@@ -132,5 +159,5 @@ class TestAgentCatchup(BaseTestEnd2EndAgentCatchup, UseGnosisSafeHardHatNet):
     KEEPER_TIMEOUT = 10
     wait_to_finish = 120
     restart_after = 45
-    check_strings = CHECK_STRINGS
+    check_strings = CHECK_STRINGS_ONLY_ROUND
     stop_string = "'registration_startup' round is done with event: Event.DONE"


### PR DESCRIPTION
## Proposed changes

in some execution of the e2e catch-up test, it might happen that
some behaviours of the delayed agent are not executed, and so
certain strings that are expected to be printed by behaviours might
not be found in the agent stdout.

This commit addresses that by fixing the "CHECK_STRINGS" set of the
price estimation abci e2e catch-up test. In particular,
strings are divided into two categories: "BEHAVIOUR" and "ROUND" strings; all the other
tests can continue to check for all the strings, whereas the e2e
test will only use the "ROUND" strings.

The variable CHECK_STRINGS_LABELLED is a list of pairs, where each pair
is (expected_output_line, string_type). We preferred this over other
data structures (e.g. a dict with type as key) so to make it easier to
add/remove strings and to keep them in the right order according to the test.

## Fixes

#417

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a