### PR TITLE
feat: specify keys to build with a flag.

### DIFF
--- a/deployments/base_deployments.py
+++ b/deployments/base_deployments.py
@@ -52,7 +52,12 @@ from aea.configurations.data_types import PublicId
 from aea.helpers.base import cd
 from aea.helpers.io import open_file
 
-from deployments.constants import CONFIG_DIRECTORY, KEYS, NETWORKS, PACKAGES_DIRECTORY
+from deployments.constants import (
+    CONFIG_DIRECTORY,
+    NETWORKS,
+    PACKAGES_DIRECTORY,
+    get_key,
+)
 
 
 COMPONENT_CONFIGS: Dict = {
@@ -337,7 +342,7 @@ class BaseDeployment:
     def generate_common_vars(self, agent_n: int) -> Dict:
         """Retrieve vars common for valory apps."""
         return {
-            "AEA_KEY": KEYS[agent_n],
+            "AEA_KEY": get_key(agent_n),
             "VALORY_APPLICATION": self.valory_application,
             "ABCI_HOST": f"abci{agent_n}" if self.network == "hardhat" else "",
             "MAX_PARTICIPANTS": self.number_of_agents,  # I believe that this is correct

--- a/deployments/click_create.py
+++ b/deployments/click_create.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2018-2019 Fetch.AI Limited
+#   Copyright 2022 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -29,13 +29,15 @@ from aea.cli.utils.loggers import logger, simple_verbosity_option
 from aea.helpers.win32 import enable_ctrl_c_support
 from pkg_resources import iter_entry_points
 
-from deployments.create_deployment import generate_deployment
+from deployments import constants
+from deployments.create_deployment import generate_deployment, read_keys
 from deployments.generators.docker_compose.docker_compose import DockerComposeGenerator
 from deployments.generators.kubernetes.kubernetes import KubernetesGenerator
 
 
 @click.command()
 @click.option("--valory-app", required=True)
+@click.option("--keys-file-path", type=str, default=None)
 @click.option(
     "--deployment-type",
     required=True,
@@ -49,8 +51,13 @@ def build_deployment(
     valory_app: str,
     deployment_type: str,
     configure_tendermint: bool,
+    keys_file_path: str = None,
 ) -> None:
     """Build the agent and its components."""
+
+    if keys_file_path is not None:
+        constants.KEYS = read_keys(keys_file_path)
+
     report = generate_deployment(
         type_of_deployment=deployment_type,
         valory_application=valory_app,

--- a/deployments/constants.py
+++ b/deployments/constants.py
@@ -112,3 +112,8 @@ Network:              $network
 Build Length          $size\n\n
 """
 )
+
+
+def get_key(key_ix: int) -> str:
+    """Retrieves the key from constants."""
+    return KEYS[key_ix]

--- a/deployments/create_deployment.py
+++ b/deployments/create_deployment.py
@@ -16,10 +16,10 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-
 """Script for generating deployment environments."""
+import json
 import os
-from typing import Dict
+from typing import Dict, List
 
 from deployments.base_deployments import BaseDeployment
 from deployments.constants import DEPLOYMENT_REPORT
@@ -76,3 +76,13 @@ def generate_deployment(
         else:
             print("To configure tendermint please run generate and run a config job.")
     return report
+
+
+def read_keys(file_path: str) -> List[str]:
+    """Read in keys from a file on disk."""
+    with open(file_path, "r", encoding="utf8") as f:
+        keys = json.loads(f.read())
+    for key in keys:
+        assert "address" in key.keys(), "Key file incorrectly formatted."
+        assert "private_key" in key.keys(), "Key file incorrectly formatted."
+    return [f["private_key"] for f in keys]

--- a/scripts/generate_bulk_keys.py
+++ b/scripts/generate_bulk_keys.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2022 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Implementation of the 'aea build_deployment' subcommand."""
+import json
+
+import click
+from aea.crypto.registries import make_crypto
+
+
+@click.command()
+@click.option("-n", "--number-of-keys", "--number_of_keys", type=int, default=4)
+@click.option(
+    "-o", "--output-file", "--output_file", type=str, default="generated_keys.json"
+)
+def generate_keys(number_of_keys: str, output_file: str) -> None:
+    """Generates n number of keys to be used by deployment generator."""
+    keys = []
+    for x in range(len(number_of_keys)):
+        account = make_crypto("ethereum")
+        keys.append({"address": account.address, "private_key": account.private_key})
+        print(f"Processed key generation {x}")
+    with open(output_file, "w", encoding="utf8") as f:
+        json.dump(keys, f, indent=4)
+
+
+if __name__ == "__main__":
+    generate_keys()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Small pr to allow;
1. generation of n number of ethereum keys and writing to disk.
2. loading of the ethereum keys into build command using --flag

Usage:

```
Usage: generate_bulk_keys.py [OPTIONS]

  Generates n number of keys to be used by deployment generator.

Options:
  -n, --number-of-keys, --number_of_keys INTEGER
  -o, --output-file, --output_file TEXT
  --help                          Show this message and exit.
```
Example
```
python scripts/generate_bulk_keys.py -n 6                                
Processed key generation 0
Processed key generation 1
Processed key generation 2
Processed key generation 3
Processed key generation 4
Processed key generation 5
```
Using the new key files;

```bash
python deployments/click_create.py build-deployment \
    --valory-app oracle_hardhat \
    --deployment-type docker-compose \
    --keys-file-path generated_keys.json

```output
To configure tendermint for deployment please run: 

docker run --rm -v $(pwd)/deployments/build/build:/tendermint:Z --entrypoint=/usr/bin/tendermint valory/consensus-algorithms-tendermint:0.1.0 testnet --config /etc/tendermint/config-template.toml --v 4 --o . --hostname=node0 --hostname=node1 --hostname=node2 --hostname=node3

Generated Deployment!


Application:          oracle_hardhat
Type:                 docker-compose
Agents:               4
Network:              hardhat
Build Length          8033
```

This can easily be confirmed as working by generating number_of_keys < number_of_agents in deployment spec which raises.