### PR TITLE
added in apt-get update to get images to build

### DIFF
--- a/deployments/Dockerfiles/open_aea/Dockerfile
+++ b/deployments/Dockerfiles/open_aea/Dockerfile
@@ -3,6 +3,7 @@ FROM valory/open-aea-user:latest
 WORKDIR /home/ubuntu
 ENV PATH=$PATH:/home/ubuntu/.local/bin
 
+RUN sudo apt-get update
 RUN sudo apt-get install python3.8 python3.8-dev git -y
 RUN cd /usr/bin && sudo rm python3 && sudo ln -s python3.8 python3 && sudo ln -s python3.8 python
 # used in Docker-compose to wait until Hardhat node is up


### PR DESCRIPTION
It appears as though the package registry needed to have an apt-get update added to resolve to moved version of packages.