### PR TITLE
docs: bump mkdocs version to 1.3.0 after jinja2 3.1.0 release

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,7 +26,7 @@ ipfshttpclient = "==0.8.0a2"
 isort = "==5.9.3"
 markdown = "==3.3.4"
 markdown-include = "==0.6.0"
-mkdocs = "==1.2.3"
+mkdocs = "==1.3.0"
 mkdocs-mermaid-plugin = {git = "https://github.com/pugong/mkdocs-mermaid-plugin.git"}
 mkdocs-material = "==7.1.10"
 multidict = "==5.2.0"

--- a/tox.ini
+++ b/tox.ini
@@ -145,7 +145,7 @@ skip_install = True
 deps =
     bs4==0.0.1
     markdown==3.3.4
-    mkdocs==1.2.3
+    mkdocs==1.3.0
     markdown-include==0.6.0
     mkdocs-material==7.1.10
     pymdown-extensions==8.2
@@ -158,7 +158,7 @@ skip_install = True
 deps =
     bs4==0.0.1
     markdown==3.3.4
-    mkdocs==1.2.3
+    mkdocs==1.3.0
     markdown-include==0.6.0
     mkdocs-material==7.1.10
     pymdown-extensions==8.2


### PR DESCRIPTION
## Proposed changes

As documented in this issue: https://github.com/mkdocs/mkdocs/issues/2799, the release of jinja2 broke the building of the documentation. The alternative to mkdocs version 1.3.0 was to use mkdocs at version 1.2.4, but since our documentation can be build correctly, this commit uses 1.3.0 despite being another minor number.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a