### PR TITLE
Included healthcheck & restart policy for tendermint node

### DIFF
--- a/deployments/Dockerfiles/localnode/Dockerfile
+++ b/deployments/Dockerfiles/localnode/Dockerfile
@@ -43,4 +43,4 @@ RUN chmod 777 -R /tendermint
 ENTRYPOINT ["/usr/bin/flask"]
 CMD ["run", "--no-reload", "--host=0.0.0.0", "--port=8080"]
 
-HEALTHCHECK --interval=3s --timeout=600s --retries=600 CMD netstat -ltn | grep -c 26658 > /dev/null; if [ 0 != $? ]; then exit 1; fi;
+HEALTHCHECK --interval=3s --timeout=600s --retries=600 CMD netstat -ltn | grep -c 26657 > /dev/null; if [ 0 != $? ]; then exit 1; fi;

--- a/deployments/generators/kubernetes/templates.py
+++ b/deployments/generators/kubernetes/templates.py
@@ -183,6 +183,7 @@ spec:
       - name: node{validator_ix}
         image: valory/consensus-algorithms-tendermint:%s
         imagePullPolicy: Always
+        restart: always
         resources:
           limits:
             memory: "1512Mi"


### PR DESCRIPTION
## Proposed changes

Add in healtcheck for docker-compose tendermint & confirm working.

Note, with this small modification, then endpoints for the containers display as healthy, when they are unhealthy, docker-compose *should* restart.


![image](https://user-images.githubusercontent.com/35799987/162762727-2990160f-ab8b-471e-a377-5e3f7592befd.png)

