### PR TITLE
Added in the build and push images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,7 @@ build-images:
 		echo "Ensure you have exported a version to build!";\
 		exit 1
 	fi
+	python deployments/click_create.py build-images --deployment-file-path ${DEPLOYMENT_SPEC} --profile dependencies || (echo failed && exit 1)
 	if [ "${VERSION}" = "dev" ];\
 	then\
 		echo "building dev images!";\
@@ -264,6 +265,7 @@ push-images:
 		exit 1
 	fi
 	if [ "${VERSION}" = "dev" ];\
+	python deployments/click_create.py build-images --deployment-file-path ${DEPLOYMENT_SPEC} --profile dependencies --push || (echo failed && exit 1)
 	then\
 		echo "building dev images!";\
 	 	python deployments/click_create.py build-images --deployment-file-path ${DEPLOYMENT_SPEC} --profile dev --push && exit 0

--- a/deployments/constants.py
+++ b/deployments/constants.py
@@ -43,6 +43,9 @@ def get_ip() -> str:
 DEFAULT_IMAGE_VERSION = "0.1.0"
 IMAGE_VERSION = os.environ.get("VERSION", DEFAULT_IMAGE_VERSION)
 
+TENDERMINT_VERSION = "0.1.0"
+HARDHAT_VERSION = "0.1.0"
+
 NETWORKS = {
     "docker-compose": {
         "hardhat": {

--- a/deployments/generators/docker_compose/templates.py
+++ b/deployments/generators/docker_compose/templates.py
@@ -19,7 +19,7 @@
 
 """Deployment Templates."""
 
-from deployments.constants import IMAGE_VERSION
+from deployments.constants import HARDHAT_VERSION, IMAGE_VERSION, TENDERMINT_VERSION
 
 
 TENDERMINT_CONFIG_TEMPLATE: str = (
@@ -32,7 +32,7 @@ valory/consensus-algorithms-tendermint:%s  \
         --o . \
         {hosts}
 """
-    % IMAGE_VERSION
+    % TENDERMINT_VERSION
 )
 
 DOCKER_COMPOSE_TEMPLATE: str = """version: "2.4"
@@ -60,7 +60,7 @@ HARDHAT_NODE_TEMPLATE: str = (
       localnet:
         ipv4_address: 192.167.11.2
 """
-    % IMAGE_VERSION
+    % HARDHAT_VERSION
 )
 
 TENDERMINT_NODE_TEMPLATE: str = (
@@ -92,7 +92,7 @@ TENDERMINT_NODE_TEMPLATE: str = (
       - ./build:/tendermint:Z
       - ../persistent_data/logs:/logs:Z
 """
-    % IMAGE_VERSION
+    % TENDERMINT_VERSION
 )
 
 ABCI_NODE_TEMPLATE: str = (
@@ -100,9 +100,9 @@ ABCI_NODE_TEMPLATE: str = (
   abci{node_id}:
     mem_limit: 1024m
     mem_reservation: 256M
-    cpus: 0.5
+    cpus: 1
     container_name: abci{node_id}
-    image: "valory/consensus-algorithms-open-aea:{valory_app}V%s"
+    image: valory/consensus-algorithms-open-aea:{valory_app}V%s
     environment:
       - LOG_FILE=/logs/aea_{node_id}.txt
 {agent_vars}

--- a/deployments/generators/kubernetes/templates.py
+++ b/deployments/generators/kubernetes/templates.py
@@ -19,7 +19,7 @@
 
 """Kubernetes Templates module."""
 
-from deployments.constants import IMAGE_VERSION
+from deployments.constants import HARDHAT_VERSION, IMAGE_VERSION, TENDERMINT_VERSION
 
 
 HARDHAT_TEMPLATE: str = (
@@ -83,7 +83,7 @@ spec:
 status:
   loadBalancer: {}
 """
-    % IMAGE_VERSION
+    % HARDHAT_VERSION
 )
 
 
@@ -99,7 +99,7 @@ spec:
       - name: regcred
       containers:
       - name: config-nodes
-        image: valory/consensus-algorithms-tendermint:{valory_app}V%s
+        image: valory/consensus-algorithms-tendermint:%s
         command: ['/usr/bin/tendermint']
         args: ["testnet",
          "--config",
@@ -141,7 +141,7 @@ spec:
     requests:
       storage: 1000M
 """
-    % IMAGE_VERSION
+    % TENDERMINT_VERSION
 )
 
 
@@ -181,7 +181,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: node{validator_ix}
-        image: valory/consensus-algorithms-tendermint:{valory_app}V%s
+        image: valory/consensus-algorithms-tendermint:%s
         imagePullPolicy: Always
         resources:
           limits:
@@ -244,6 +244,6 @@ spec:
           persistentVolumeClaim:
             claimName: 'build-vol-pvc'
 """ % (
-    IMAGE_VERSION,
+    TENDERMINT_VERSION,
     IMAGE_VERSION,
 )

--- a/deployments/image_builder.py
+++ b/deployments/image_builder.py
@@ -48,7 +48,7 @@ class ImageBuilder:
         agent_id = PublicId.from_str(aea_agent)
         env["AEA_AGENT"] = aea_agent
         env["VERSION"] = f"{agent_id.name}V{env['VERSION']}"
-        if profile in ["cluster", "dev"]:
+        if profile in ["cluster", "dev", "dependencies"]:
             skaffold_profile = profile
         else:
             skaffold_profile = "prod"

--- a/deployments/readme.md
+++ b/deployments/readme.md
@@ -45,6 +45,26 @@ Images are built & tagged by a python script which uses calls Skaffold based on 
 
 This is done from the root directory.
 
+The first time we run the application, we must also build and tag the dependency images. 
+
+These images are used for tendermint and for the local hardhat image.
+
+```bash
+make clean
+python deployments/click_create.py build-images \
+  --valory-app oracle_hardhat \
+  --profile dependencies 
+...  
+Generating tags...
+ - valory/consensus-algorithms-tendermint -> valory/consensus-algorithms-tendermint:0.1.0
+ - valory/consensus-algorithms-hardhat -> valory/consensus-algorithms-hardhat:0.1.0
+Checking cache...
+ - valory/consensus-algorithms-tendermint: Found Locally
+ - valory/consensus-algorithms-hardhat: Found Locally
+```
+
+Now we have our base dependencies, we can build the application specific dependencies.
+
 ```bash
 make clean
 export VERSION=0.1.0
@@ -60,14 +80,9 @@ From this command, we receive the below output showing custom images being built
 ... 
 Generating tags...
  - valory/consensus-algorithms-open-aea -> valory/consensus-algorithms-open-aea:oracle_deployableV0.1.0
- - valory/consensus-algorithms-tendermint -> valory/consensus-algorithms-tendermint:oracle_deployableV0.1.0
- - valory/consensus-algorithms-hardhat -> valory/consensus-algorithms-hardhat:oracle_deployableV0.1.0
 Checking cache...
- - valory/consensus-algorithms-open-aea: Found Locally
- - valory/consensus-algorithms-tendermint: Found Locally
- - valory/consensus-algorithms-hardhat: Found Locally
+ - valory/consensus-algorithms-open-aea: Found. Tagging
 ```
-
 
 # Step 2
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -12,26 +12,31 @@ build:
     docker:
       dockerfile: Dockerfile
       buildArgs:
-        AEA_VERSION: "0.1.7"
+        AEA_VERSION: "1.7.0"
         AEA_AGENT: "{{.AEA_AGENT}}"
 
-  - image: valory/consensus-algorithms-tendermint
-    context: deployments/Dockerfiles/localnode/
-    docker:
-      dockerfile: Dockerfile
-
-
-  - image: valory/consensus-algorithms-hardhat
-    context: deployments/Dockerfiles/hardhat
 
 profiles:
+  - name: prod
+  - name: dependencies
+    build:
+      tagPolicy:
+        envTemplate:
+          template: "0.1.0"
+      artifacts:
+      - image: valory/consensus-algorithms-tendermint
+        context: deployments/Dockerfiles/localnode/
+        docker:
+          dockerfile: Dockerfile
+      - image: valory/consensus-algorithms-hardhat
+        context: deployments/Dockerfiles/hardhat
   - name: cluster
     patches:
       - op: add
         path: /build/artifacts/0/kaniko
-        value: 
+        value:
           buildArgs:
-            AEA_VERSION: "0.1.7"
+            AEA_VERSION: "1.7.0"
             AEA_AGENT: "{{.AEA_AGENT}}"
       - op: add
         path: /build/cluster
@@ -41,10 +46,6 @@ profiles:
             path: ~/.docker/config.json
       - op: remove
         path: /build/artifacts/0/docker
-      - op: remove
-        path: /build/artifacts/1/docker
-
-  - name: prod
   - name: dev
     patches:
       - op: replace
@@ -52,7 +53,4 @@ profiles:
         value: Dockerfile.develop
       - op: add
         path: /build/artifacts/0/docker/cliFlags
-        value: ["--no-cache", "--pull", "--force-rm"]
-      - op: add
-        path: /build/artifacts/1/docker/cliFlags
         value: ["--no-cache", "--pull", "--force-rm"]


### PR DESCRIPTION
This pr seperates the dependency images from the rest application images.

This allows us to seperatesly build and push our dependencies. as so;

These images are used for tendermint and for the local hardhat image.

```bash
make clean
python deployments/click_create.py build-images \
  --valory-app oracle_hardhat \
  --profile dependencies 
...  
Generating tags...
 - valory/consensus-algorithms-tendermint -> valory/consensus-algorithms-tendermint:0.1.0
 - valory/consensus-algorithms-hardhat -> valory/consensus-algorithms-hardhat:0.1.0
Checking cache...
 - valory/consensus-algorithms-tendermint: Found Locally
 - valory/consensus-algorithms-hardhat: Found Locally
```

Now we have our base dependencies, we can build the application specific dependencies.

```
make clean
export VERSION=0.1.0
python deployments/click_create.py build-images \
    --valory-app  oracle_hardhat \
    --profile $VERSION
```

This is compatible with the oracle dev mode and the other make file commands