### PR TITLE
Fix/file paths

### DIFF
--- a/deployments/Dockerfiles/localnode/Dockerfile
+++ b/deployments/Dockerfiles/localnode/Dockerfile
@@ -45,4 +45,4 @@ RUN chmod 777 -R /tm_state
 ENTRYPOINT ["/usr/bin/flask"]
 CMD ["run", "--no-reload", "--host=0.0.0.0", "--port=8080"]
 
-HEALTHCHECK --interval=3s --timeout=10s --retries=3 CMD netstat -ltn | grep -c 26657 > /dev/null; if [ 0 != $? ]; then exit 1; fi;
+HEALTHCHECK --interval=3s --timeout=600s --retries=600 CMD netstat -ltn | grep -c 26657 > /dev/null; if [ 0 != $? ]; then exit 1; fi;


### PR DESCRIPTION
# Bug / Improvement

I noticed that the flask server does write its logs to the file, meaning its difficult to see in the logs, when the tm process has been stopped by the flask server or when it has just failed.

```

tail -f deployments/persistent_data/logs/node_0.txt 


================================
start
================================
2022-05-10 11:13:37,333 WARNING werkzeug MainThread :  * Running on all addresses.
   WARNING: This is a development server. Do not use it in a production deployment.
2022-05-10 11:13:37,334 INFO werkzeug MainThread :  * Running on http://192.167.11.3:8080/ (Press CTRL+C to quit)
I[2022-05-10|11:13:37.461] Starting multiAppConn service                module=proxy impl=multiAppConn
I[2022-05-10|11:13:37.461] Starting socketClient service                module=abci-client connection=query impl=socketClient
I[2022-05-10|11:13:37.461] Starting socketClient service                module=abci-client connection=snapshot impl=socketClient
I[2022-05-10|11:13:37.462] Starting socketClient service                module=abci-client connection=mempool impl=socketClient
```

Now, we can see the reset events within the logs as so;

```bash
tail -f deployments/persistent_data/logs/node_0.txt 

I[2022-05-10|11:18:23.994] Stopping Mempool service                     module=mempool impl=Mempool
I[2022-05-10|11:18:23.994] Stopping BlockchainReactor service           module=blockchain impl=BlockchainReactor
I[2022-05-10|11:18:23.994] Stopping Consensus service                   module=consensus impl=ConsensusReactor
I[2022-05-10|11:18:23.994] Stopping State service                       module=consensus impl=ConsensusState
I[2022-05-10|11:18:23.994] Stopping TimeoutTicker service               module=consensus impl=TimeoutTicker
I[2022-05-10|11:18:23.994] Stopping baseWAL service                     module=consensus wal=/tendermint/node0/data/cs.wal/wal impl=baseWAL
I[2022-05-10|11:18:23.994] Stopping Group service                       module=consensus wal=/tendermint/node0/data/cs.wal/wal impl=Group
I[2022-05-10|11:18:23.994] Stopping Evidence service                    module=evidence impl=Evidence
I[2022-05-10|11:18:23.994] Stopping StateSync service                   module=statesync impl=StateSync
E[2022-05-10|11:18:23.994] Stopped accept routine, as transport is closed module=p2p numPeers=0
I[2022-05-10|11:18:23.994] Closing rpc listener                         module=main listener="&{Listener:0xc00015c3a8 sem:0xc0003a4360 closeOnce:{done:0 m:{state:0 sema:0}} done:0xc0003a43c0}"
I[2022-05-10|11:18:23.994] RPC HTTP server stopped                      module=rpc-server err="accept tcp [::]:26657: use of closed network connection"
E[2022-05-10|11:18:23.994] Error serving server                         module=main err="accept tcp [::]:26657: use of closed network connection"

================================
start
================================
2022-05-10 11:18:23,997 INFO werkzeug Thread-1 : 127.0.0.1 - - [10/May/2022 11:18:23] "GET /gentle_reset HTTP/1.1" 200 -
I[2022-05-10|11:18:24.064] Starting multiAppConn service                module=proxy impl=multiAppConn
I[2022-05-10|11:18:24.064] Starting socketClient service                module=abci-client connection=query impl=socketClient
I[2022-05-10|11:18:24.065] Starting socketClient service                module=abci-client connection=snapshot impl=socketClient
I[2022-05-10|11:18:24.065] Starting socketClient service                module=abci-client connection=mempool impl=socketClient
I[2022-05-10|11:18:24.065] Starting socketClient service                module=abci-client connection=consensus impl=socketClient
I[2022-05-10|11:18:24.066] Starting EventBus service                    module=events impl=EventBus
I[2022-05-10|11:18:24.066] Starting PubSub service                      module=pubsub impl=PubSub
I[2022-05-10|11:18:24.082] Starting IndexerService service              module=txindex impl=IndexerService
I[2022-05-10|11:18:24.086] ABCI Handshake App Info                      module=consensus height=215 hash= software-version= protocol-version=0
I[2022-05-10|11:18:24.086] ABCI Replay Blocks                           module=consensus appHeight=215 storeHeight=215 stateHeight=215
I[2022-05-10|11:18:24.086] Completed ABCI Handshake - Tendermint and App are synced module=consensus appHeight=215 appHash=
I[2022-05-10|11:18:24.087] Version info                                 module=main tendermint_version=0.34.11 block=11 p2p=8
I[2022-05-10|11:18:24.087] This node is a validator                     module=consensus addr=A10E2CF4163F55D208854B7B9D8CBAC0FA77209E pubKey=PubKeyEd25519{6A1371C302BDCC9D3646E03E05E465095FF351AD002218EFFA364BFDB51F5721}
I[2022-05-10|11:18:24.097] P2P Node ID                                  module=p2p ID=fbb8853d9ee93a6915d38b58d9720058b24f1c7c file=/tendermint/node0/config/node_key.json
```

# Application Control Flow

Within a deployment, each individual tendermint node consists of a:
- Tendermint Node
- ABCI application

Each of these is implemented as a docker image which is deployed in a 1-2-1 relationship.

The tendermint image is implemented as a flask server built on top of the ```valory/tendermint``` image.

## Tendermint Image control flow. 

```mermaid
flowchart TD
    subgraph Tendermint  Container
        A[Flask EntryPoint] --> Flask
        STDOUT --> Monitoring
        Monitoring --> LOG
        Flask --> LOG
        Flask --> Monitoring
        Flask --> StartA
        
        subgraph FP[Flask Process]
            Flask((Flask Server))
            subgraph Tendermint Process
                Tendermint((Tendermint Process))
                StartA[Tendermint Process] --> Tendermint
                Tendermint --> STDOUT[STDOUT]
            end
            subgraph Monitoring Thread
                Monitoring((Monitoring Thread))
            end
        end
    end
```


```mermaid
flowchart LR
    subgraph AEA Container
        start.sh --> A[Pull Aea]
        A --> b[Run AEA]
        subgraph AEA Process
            b[Run AEA]
        end
        b-->LOG[Log File]
    end
```

