### PR TITLE
updated pvc to use nfs client provisioner

### DIFF
--- a/aea_swarm/deploy/generators/kubernetes/templates.py
+++ b/aea_swarm/deploy/generators/kubernetes/templates.py
@@ -126,7 +126,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: logs-pvc
 spec:
-  storageClassName: nfs
+  storageClassName: nfs-client
   accessModes:
     - ReadWriteOnce
   resources:
@@ -138,7 +138,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: tendermint-pvc
 spec:
-  storageClassName: nfs
+  storageClassName: nfs-client
   accessModes:
     - ReadWriteOnce
   resources:
@@ -150,7 +150,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: benchmark-pvc
 spec:
-  storageClassName: nfs
+  storageClassName: nfs-client
   accessModes:
     - ReadWriteOnce
   resources:
@@ -162,7 +162,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: nodes
 spec:
-  storageClassName: nfs
+  storageClassName: nfs-client
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
This very small pr simply modifies the storage class to use the new nfs-client to connect to the AWS elastic storage mount.