### PR TITLE
Fix/tm dockerfile

### DIFF
--- a/packages/valory/services/apy_estimation_hardhat/service.yaml
+++ b/packages/valory/services/apy_estimation_hardhat/service.yaml
@@ -1,126 +1,32 @@
-
-  
-name: oracle_hardhat
+name: apy_estimation
+author: "valory"
 version: 0.1.0
-author: valory
-agent: valory/oracle_deployable:0.1.0
+agent: "valory/apy_estimation_deployable:0.1.0"
 network: hardhat
 number_of_agents: 4
 ---
-benchmark_persistence_params:
-  args: &id003
-    log_dir: /benchmarks
-observation_params:
-  args: &id001
-    observation_interval: 30
-    broadcast_to_server: false
-valory_monitoring_backend:
-  args: &id002
-    url: https://staging.oracle-server.autonolas.tech/deposit
-public_id: valory/oracle_abci:0.1.0
+public_id: valory/apy_estimation_abci:0.1.0
 type: skill
 models:
-  0:
-  - price_api:
-      args:
-        url: https://api.coingecko.com/api/v3/simple/price
-        api_id: coingecko
-        parameters: '[["ids", "bitcoin"], ["vs_currencies", "usd"]]'
-        response_key: bitcoin:usd
-        headers: null
-  - randomness_api:
-      args:
-        url: https://drand.cloudflare.com/public/latest
-        api_id: cloudflare
-  - params:
-      args: *id001
-  - server_api:
-      args: *id002
-  - benchmark_tool:
-      args: *id003
-  1:
-  - price_api:
-      args:
-        url: https://ftx.com/api/markets/BTC/USD
-        api_id: ftx
-        response_key: result:last
-        headers: null
-        parameters: null
-  - randomness_api:
-      args:
-        url: https://api.drand.sh/public/latest
-        api_id: protocollabs1
-  - params:
-      args: *id001
-  - server_api:
-      args: *id002
-  - benchmark_tool:
-      args: *id003
-  2:
-  - price_api:
-      args:
-        url: https://api.coinbase.com/v2/prices/BTC-USD/buy
-        api_id: coinbase
-        response_key: data:amount
-        headers: null
-        parameters: null
-  - randomness_api:
-      args:
-        url: https://api2.drand.sh/public/latest
-        api_id: protocollabs2
-  - params:
-      args: *id001
-  - server_api:
-      args: *id002
-  - benchmark_tool:
-      args: *id003
-  3:
-  - price_api:
-      args:
-        url: https://api.binance.com/api/v3/ticker/price
-        api_id: binance
-        parameters: '[["symbol", "BTCUSDT"]]'
-        response_key: price
-        headers: null
-  - randomness_api:
-      args:
-        url: https://api3.drand.sh/public/latest
-        api_id: protocollabs3
-  - params:
-      args: *id001
-  - server_api:
-      args: *id002
-  - benchmark_tool:
-      args: *id003
-# name: apy_estimation
-# author: "valory"
-# version: 0.1.0
-# agent: "valory/apy_estimation_deployable:0.1.0"
-# network: hardhat
-# number_of_agents: 4
-# ---
-# public_id: valory/apy_estimation_abci:0.1.0
-# type: skill
-# models:
-#   params:
-#     args:
-#       consensus:
-#         max_participants: 4
-#       round_timeout_seconds: 1000.0
-#       observation_interval: 86400
-#       max_healthcheck: 43200
-#       drand_public_key: 868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31
-#       estimation:
-#         steps_forward: 1
-#       history_duration: 6
-#       optimizer:
-#         n_trials: 10
-#         timeout: 60
-#         n_jobs: 1
-#         show_progress_bar: false
-#         scoring: pinball
-#         alpha: 0.25
-#       pair_ids: '["0x2b4c76d0dc16be1c31d4c1dc53bf9b45987fc75c"]'
-#       sleep_time: 10
-#       ipfs_domain_name: /dns/staging.registry.autonolas.tech/tcp/443/https
-# 
+  params:
+    args:
+      consensus:
+        max_participants: 4
+      round_timeout_seconds: 1000.0
+      observation_interval: 86400
+      max_healthcheck: 43200
+      drand_public_key: 868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31
+      estimation:
+        steps_forward: 1
+      history_duration: 6
+      optimizer:
+        n_trials: 10
+        timeout: 60
+        n_jobs: 1
+        show_progress_bar: false
+        scoring: pinball
+        alpha: 0.25
+      pair_ids: '["0x2b4c76d0dc16be1c31d4c1dc53bf9b45987fc75c"]'
+      sleep_time: 10
+      ipfs_domain_name: /dns/staging.registry.autonolas.tech/tcp/443/https
+


### PR DESCRIPTION
Small pr to fix the deployment post create_app fixes.

flask expects a singular app to be returned not a tuple, we cant pass arguments and its bad practise to change return types based on bools.