### PR TITLE
lint: avoid bare except in deployments/Dockerfiles/localnode/app.py

### DIFF
--- a/deployments/Dockerfiles/localnode/app.py
+++ b/deployments/Dockerfiles/localnode/app.py
@@ -33,7 +33,7 @@ from werkzeug.exceptions import InternalServerError, NotFound
 
 try:
     from .tendermint import TendermintNode, TendermintParams
-except:
+except ImportError:
     from tendermint import TendermintNode, TendermintParams
 
 DEFAULT_LOG_FILE = "log.log"


### PR DESCRIPTION
## Proposed changes

Just a minor fix to deployments/Dockerfiles/localnode/app.py such that `make lint` does not fail: 

```
flake8 aea_swarm packages/valory scripts tests deployments
deployments/Dockerfiles/localnode/app.py:36:1: E722 do not use bare 'except'
deployments/Dockerfiles/localnode/app.py:36:1: B001 Do not use bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on.  Prefer `except Exception:`.  If you're sure what you're doing, be explicit and write `except BaseException:`.
make: *** [lint] Error 1

```


## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a