### PR TITLE
fix: skip python block in test

### DIFF
--- a/tests/test_docs/test_code_blocks.py
+++ b/tests/test_docs/test_code_blocks.py
@@ -188,7 +188,8 @@ class TestPythonSnippets(BaseTestDocCode):
 
     skipped_files = [
         "docs/abci_app_async_behaviour.md",  # just placeholder examples
-        "docs/networks.md",  # only irrelevant one-liners
+        "docs/networks.md",  # only irrelevant one-liners,
+        "docs/abci_app_abstract_round.md",  # just a placeholder example
     ]
 
 


### PR DESCRIPTION
## Proposed changes

Skip a very simple python block in one of our doc tests that is failing.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

