### PR TITLE
Disable config loader warning

### DIFF
--- a/autonomy/configurations/base.py
+++ b/autonomy/configurations/base.py
@@ -302,11 +302,7 @@ class Service(PackageConfiguration):  # pylint: disable=too-many-instance-attrib
                 overrides = self.try_to_process_singular_override(
                     component_id, config_class, configuration
                 )
-            except ValueError as e:
-                print(
-                    f"Failed to parse as a singular input with {e}\nAttempting with nested fields."
-                )
-
+            except ValueError:
                 overrides = self.try_to_process_nested_fields(
                     component_id,
                     component_index,


### PR DESCRIPTION
## Proposed changes

This PR disables the nested field parser warning on service config loader

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
