### PR TITLE
Increase observation interval for tests that reset Tendermint nodes

### DIFF
--- a/tests/test_agents/test_oracle_abci.py
+++ b/tests/test_agents/test_oracle_abci.py
@@ -144,6 +144,10 @@ class TestTendermintReset(TestABCIPriceEstimationFourAgents):
             "dotted_path": f"{__args_prefix}.reset_tendermint_after",
             "value": 2,
         },
+        {
+            "dotted_path": f"{__args_prefix}.observation_interval",
+            "value": 15,
+        },
     ]
 
 
@@ -172,6 +176,10 @@ class TestTendermintResetInterrupt(TestAgentCatchup):
         {
             "dotted_path": f"{__args_prefix}.reset_tendermint_after",
             "value": __reset_tendermint_every,
+        },
+        {
+            "dotted_path": f"{__args_prefix}.observation_interval",
+            "value": 15,
         },
     ]
 

--- a/tests/test_agents/test_register_reset_abci.py
+++ b/tests/test_agents/test_register_reset_abci.py
@@ -46,6 +46,13 @@ class TestTendermintStartup(BaseTestEnd2EndNormalExecution):
         "reset_and_pause": 1,
     }
     wait_to_finish = 60
+    __args_prefix = f"vendor.valory.skills.{PublicId.from_str(skill_package).name}.models.params.args"
+    extra_configs = [
+        {
+            "dotted_path": f"{__args_prefix}.observation_interval",
+            "value": 15,
+        },
+    ]
 
 
 @pytest.mark.parametrize("nb_nodes", (4,))
@@ -63,6 +70,10 @@ class TestTendermintReset(BaseTestEnd2EndNormalExecution):
         {
             "dotted_path": f"{__args_prefix}.reset_tendermint_after",
             "value": __reset_tendermint_every,
+        },
+        {
+            "dotted_path": f"{__args_prefix}.observation_interval",
+            "value": 15,
         },
     ]
 
@@ -87,6 +98,10 @@ class TestTendermintResetInterrupt(BaseTestEnd2EndAgentCatchup):
         {
             "dotted_path": f"{__args_prefix}.reset_tendermint_after",
             "value": __reset_tendermint_every,
+        },
+        {
+            "dotted_path": f"{__args_prefix}.observation_interval",
+            "value": 15,
         },
     ]
 


### PR DESCRIPTION
## Proposed changes

When resetting with Tendermint, the `observation_interval/2` is used in order to wait when entering and exiting the reset round. However, in #904 we updated the observation interval for all the tests to 3. As a result, we only wait for 1.5sec when entering the reset round before the reset begins. This may result in the **minority** of the agents reset and when they enter back they cannot continue. Therefore, this PR increases the observation interval for the tests that also reset Tendermint nodes in order to allow the majority of the agents to reset properly.

However, this is limiting for the developer because it cannot use a very small value for the observation interval.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

This fixes the tests, however, does not fix the issue because the developer may still choose a tiny amount for the observation interval, which is going to break the reset with Tendermint. We should probably restrict the user from inserting a small amount for the observation interval.