### PR TITLE
Shift com port to avoid conflicts

### DIFF
--- a/tests/helpers/docker/tendermint.py
+++ b/tests/helpers/docker/tendermint.py
@@ -129,7 +129,7 @@ class FlaskTendermintDockerImage(TendermintDockerImage):
         abci_port: int = DEFAULT_ABCI_PORT,
         port: int = DEFAULT_TENDERMINT_PORT,
         p2p_port: int = DEFAULT_P2P_PORT,
-        com_port: int = DEFAULT_TENDERMINT_COM_PORT,
+        com_port: int = DEFAULT_TENDERMINT_COM_PORT + 2,
     ):
         """Initialize."""
         super().__init__(client, abci_host, abci_port, port, p2p_port, com_port)
@@ -154,12 +154,6 @@ class FlaskTendermintDockerImage(TendermintDockerImage):
             ]
             subprocess.run(cmd)  # nosec
             os.chdir(cwd)
-
-    @property
-    def local_com_port(self) -> int:
-        """Get the port on which the com port will be mapped locally."""
-        # we do this to avoid using 8080
-        return self.com_port + 2
 
     @property
     def tag(self) -> str:
@@ -201,7 +195,7 @@ class FlaskTendermintDockerImage(TendermintDockerImage):
 
     def get_com_port(self, i: int) -> int:
         """Get the ith com port."""
-        return self.__increment_port(self.local_com_port, i)
+        return self.__increment_port(self.com_port, i)
 
     def get_p2p_port(self, i: int) -> int:
         """Get the ith p2p port."""

--- a/tests/helpers/docker/tendermint.py
+++ b/tests/helpers/docker/tendermint.py
@@ -156,6 +156,12 @@ class FlaskTendermintDockerImage(TendermintDockerImage):
             os.chdir(cwd)
 
     @property
+    def local_com_port(self) -> int:
+        """Get the port on which the com port will be mapped locally."""
+        # we do this to avoid using 8080
+        return self.com_port + 2
+
+    @property
     def tag(self) -> str:
         """Get the tag."""
         return f"{TENDERMINT_IMAGE_NAME}:{TENDERMINT_IMAGE_VERSION}"
@@ -195,7 +201,7 @@ class FlaskTendermintDockerImage(TendermintDockerImage):
 
     def get_com_port(self, i: int) -> int:
         """Get the ith com port."""
-        return self.__increment_port(self.com_port, i)
+        return self.__increment_port(self.local_com_port, i)
 
     def get_p2p_port(self, i: int) -> int:
         """Get the ith p2p port."""


### PR DESCRIPTION
## Proposed changes

Shifts com port to avoid conflicts while running APY e2e tests.

There was a conflict in the APY e2e tests because they start a local IPFS node that is using a read-only gateway server, listening on `/ip4/127.0.0.1/tcp/8080`.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a