### PR TITLE
Enable e2e tests to check for successful events other than `DONE`

### DIFF
--- a/tests/test_agents/base.py
+++ b/tests/test_agents/base.py
@@ -130,10 +130,6 @@ class BaseTestEnd2End(AEATestCaseMany, UseFlaskTendermintNode):
             ANY_ADDRESS,
         )
         self.set_config(
-            "vendor.valory.connections.abci.config.host",
-            ANY_ADDRESS,
-        )
-        self.set_config(
             "vendor.valory.connections.abci.config.port",
             self.get_abci_port(i),
         )

--- a/tests/test_agents/base.py
+++ b/tests/test_agents/base.py
@@ -109,9 +109,10 @@ class BaseTestEnd2End(AEATestCaseMany, UseFlaskTendermintNode):
         dotted_path: str,
         value: Any,
         type_: Optional[str] = None,
+        aev: bool = True,
     ) -> Result:
         """Set config value."""
-        return super().set_config(dotted_path, value, type_, aev=True)
+        return super().set_config(dotted_path, value, type_, aev)
 
     def __set_extra_configs(self) -> None:
         """Set the current agent's extra config overrides that are skill specific."""

--- a/tests/test_agents/base.py
+++ b/tests/test_agents/base.py
@@ -23,6 +23,7 @@ import logging
 import os
 import time
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -35,6 +36,21 @@ from tests.fixture_helpers import UseFlaskTendermintNode
 
 
 _HTTP = "http://"
+
+
+@dataclass
+class RoundChecks:
+    """
+    Class for the necessary checks of a round during the tests.
+
+    name: is the name of the round for which the checks should be performed.
+    event: is the name of the event that is considered as successful.
+    n_periods: is the number of periods this event should appear for the check to be considered successful.
+    """
+
+    name: str
+    success_event: str = "DONE"
+    n_periods: int = 1
 
 
 @pytest.mark.e2e

--- a/tests/test_agents/test_hello_world.py
+++ b/tests/test_agents/test_hello_world.py
@@ -20,16 +20,15 @@
 """End2end tests for the valory/hello_world skill."""
 import pytest
 
-from tests.test_agents.base import BaseTestEnd2EndNormalExecution
+from tests.test_agents.base import BaseTestEnd2EndNormalExecution, RoundChecks
 
 
-# round check log messages of the happy path
-EXPECTED_ROUND_LOG_COUNT = {
-    "registration": 1,
-    "print_message": 3,
-    "select_keeper": 2,
-    "reset_and_pause": 2,
-}
+HAPPY_PATH = (
+    RoundChecks("registration"),
+    RoundChecks("print_message", n_periods=3),
+    RoundChecks("select_keeper", n_periods=2),
+    RoundChecks("reset_and_pause", n_periods=2),
+)
 
 # strict check log messages of the happy path
 STRICT_CHECK_STRINGS = (
@@ -50,5 +49,5 @@ class TestHelloWorldABCIFourAgents(
     agent_package = "valory/hello_world:0.1.0"
     skill_package = "valory/hello_world_abci:0.1.0"
     wait_to_finish = 160
-    round_check_strings_to_n_periods = EXPECTED_ROUND_LOG_COUNT
+    happy_path = HAPPY_PATH
     strict_check_strings = STRICT_CHECK_STRINGS

--- a/tests/test_agents/test_oracle_abci.py
+++ b/tests/test_agents/test_oracle_abci.py
@@ -180,8 +180,6 @@ class TestTendermintResetInterrupt(TestAgentCatchup):
 
     # stop for restart_after seconds when resetting Tendermint for the first time (using -1 because count starts from 0)
     stop_string = f"Entered in the 'reset_and_pause' round for period {__reset_tendermint_every - 1}"
-    # check if we manage to reset with Tendermint `__n_resets_to_perform` times with the rest of the agents
-    exclude_from_checks = [3]
     happy_path = _generate_reset_happy_path(
         __n_resets_to_perform, __reset_tendermint_every
     )
@@ -211,3 +209,5 @@ class TestTendermintResetInterruptNoRejoin(TestTendermintResetInterrupt):
     wait_to_finish = 300
     # set the restart to a value so that the agent never rejoins, in order to test the impact to the rest of the agents
     restart_after = wait_to_finish
+    # check if we manage to reset with Tendermint `__n_resets_to_perform` times with the rest of the agents
+    exclude_from_checks = [3]

--- a/tests/test_agents/test_oracle_abci.py
+++ b/tests/test_agents/test_oracle_abci.py
@@ -32,7 +32,7 @@ from tests.test_agents.base import (
 )
 
 
-HAPPY_PATH = (
+HAPPY_PATH: Tuple[RoundChecks, ...] = (
     RoundChecks("registration_startup"),
     RoundChecks("randomness_safe"),
     RoundChecks("select_keeper_safe"),

--- a/tests/test_agents/test_register_reset_abci.py
+++ b/tests/test_agents/test_register_reset_abci.py
@@ -24,15 +24,15 @@ from aea.configurations.data_types import PublicId
 from tests.test_agents.base import (
     BaseTestEnd2EndAgentCatchup,
     BaseTestEnd2EndNormalExecution,
+    RoundChecks,
 )
 
 
-# round check log messages of the happy path
-EXPECTED_ROUND_LOG_COUNT = {
-    "registration_startup": 1,
-    "registration": 3,
-    "reset_and_pause": 4,
-}
+HAPPY_PATH = (
+    RoundChecks("registration_startup"),
+    RoundChecks("registration", n_periods=3),
+    RoundChecks("reset_and_pause", n_periods=4),
+)
 
 
 @pytest.mark.parametrize("nb_nodes", (4,))
@@ -41,10 +41,10 @@ class TestTendermintStartup(BaseTestEnd2EndNormalExecution):
 
     agent_package = "valory/register_reset:0.1.0"
     skill_package = "valory/register_reset_abci:0.1.0"
-    round_check_strings_to_n_periods = {
-        "registration_startup": 1,
-        "reset_and_pause": 1,
-    }
+    happy_path = (
+        RoundChecks("registration_startup"),
+        RoundChecks("reset_and_pause"),
+    )
     wait_to_finish = 60
     __args_prefix = f"vendor.valory.skills.{PublicId.from_str(skill_package).name}.models.params.args"
     extra_configs = [
@@ -61,7 +61,7 @@ class TestTendermintReset(BaseTestEnd2EndNormalExecution):
 
     agent_package = "valory/register_reset:0.1.0"
     skill_package = "valory/register_reset_abci:0.1.0"
-    round_check_strings_to_n_periods = EXPECTED_ROUND_LOG_COUNT
+    happy_path = HAPPY_PATH
     wait_to_finish = 200
     __reset_tendermint_every = 1
     __args_prefix = f"vendor.valory.skills.{PublicId.from_str(skill_package).name}.models.params.args"
@@ -90,7 +90,7 @@ class TestTendermintResetInterrupt(BaseTestEnd2EndAgentCatchup):
     restart_after = 1
     __reset_tendermint_every = 1
     stop_string = f"Entered in the 'reset_and_pause' round for period {__reset_tendermint_every - 1}"
-    round_check_strings_to_n_periods = EXPECTED_ROUND_LOG_COUNT
+    happy_path = HAPPY_PATH
 
     __args_prefix = f"vendor.valory.skills.{PublicId.from_str(skill_package).name}.models.params.args"
     # reset every `__reset_tendermint_every` rounds

--- a/tests/test_agents/test_simple_abci.py
+++ b/tests/test_agents/test_simple_abci.py
@@ -20,16 +20,16 @@
 """End2end tests for the valory/simple_abci skill."""
 import pytest
 
-from tests.test_agents.base import BaseTestEnd2EndNormalExecution
+from tests.test_agents.base import BaseTestEnd2EndNormalExecution, RoundChecks
 
 
 # round check log messages of the happy path
-EXPECTED_ROUND_LOG_COUNT = {
-    "registration": 1,
-    "randomness_startup": 3,
-    "select_keeper_at_startup": 2,
-    "reset_and_pause": 2,
-}
+HAPPY_PATH = (
+    RoundChecks("registration"),
+    RoundChecks("randomness_startup", n_periods=3),
+    RoundChecks("select_keeper_at_startup", n_periods=2),
+    RoundChecks("reset_and_pause", n_periods=2),
+)
 
 # strict check log messages of the happy path
 STRICT_CHECK_STRINGS = ("Period end",)
@@ -44,7 +44,7 @@ class TestSimpleABCISingleAgent(
     agent_package = "valory/simple_abci:0.1.0"
     skill_package = "valory/simple_abci:0.1.0"
     wait_to_finish = 80
-    round_check_strings_to_n_periods = EXPECTED_ROUND_LOG_COUNT
+    happy_path = HAPPY_PATH
     strict_check_strings = STRICT_CHECK_STRINGS
     use_benchmarks = True
 
@@ -58,7 +58,7 @@ class TestSimpleABCITwoAgents(
     agent_package = "valory/simple_abci:0.1.0"
     skill_package = "valory/simple_abci:0.1.0"
     wait_to_finish = 120
-    round_check_strings_to_n_periods = EXPECTED_ROUND_LOG_COUNT
+    happy_path = HAPPY_PATH
     strict_check_strings = STRICT_CHECK_STRINGS
 
 
@@ -71,5 +71,5 @@ class TestSimpleABCIFourAgents(
     agent_package = "valory/simple_abci:0.1.0"
     skill_package = "valory/simple_abci:0.1.0"
     wait_to_finish = 120
-    round_check_strings_to_n_periods = EXPECTED_ROUND_LOG_COUNT
+    happy_path = HAPPY_PATH
     strict_check_strings = STRICT_CHECK_STRINGS


### PR DESCRIPTION
## Proposed changes

We now define a happy path for our e2e tests, using a `RoundChecks` dataclass. This enables us to specify the name of the successful event which previously could only be `DONE` for the test to succeed. This will also allow us to re-enable the APY e2e tests.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [x] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a