### PR TITLE
Feat/v0.1.2

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -150,6 +150,10 @@ PyPI
 white_check_mark
 subgraph
 DevOps
+spookyswap
+config
+codeql
+os
  - docs/index.md
 README.md
 s_

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,30 @@
 # Release History - `open-autonomy`
 
+
+## 0.1.2 (2022-07-08)
+
+Autonomy:
+- Updates `hash all` command to update agent hashes on service components when hashing service components
+- Adds tests for missing coverage
+
+Packages:
+- Adds service for `hello_world` agent
+- Introduces `raise_on_try` parameter in nested contract calls
+- Introduces mechanism to enforce round id uniqueness
+- Adds a method to clean the current period history for every parameter in the DB
+- Adds parameter that users can optionally configure so period history is cleaned on every reset
+- Fixes list representation in config YAML files
+- Adds check for `unsafe-reset-all` to verify if the command exited successfully
+
+Chores:
+- Fixes `atheris` installation
+- Adds CodeQL analysis
+
+Docs:
+- Adds documentation for `TendermintHandler` class
+- Updates communication flows.
+- Updates fonts and colours
+
 ## 0.1.1 (2022-06-22)
 
 Autonomy:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-autonomy` are currently being 
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `0.1.1`   | :white_check_mark: |
-| `< 0.1.1` | :x:                |
+| `0.1.2`   | :white_check_mark: |
+| `< 0.1.2` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/autonomy/__version__.py
+++ b/autonomy/__version__.py
@@ -22,7 +22,7 @@
 __title__ = "open-autonomy"
 __description__ = "A framework for the creation of autonomous agent services."
 __url__ = "https://github.com/valory-xyz/open-autonomy.git"
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021-2022 Valory AG"

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -5,6 +5,10 @@ Below we describe the additional manual steps required to upgrade between differ
 
 # Open Autonomy
 
+## `v0.1.1` to `v0.1.2`
+
+No backwards incompatible changes
+
 ## `v0.1.0` to `v0.1.1`
 
 No backwards incompatible changes

--- a/scripts/RELEASE_PROCESS.md
+++ b/scripts/RELEASE_PROCESS.md
@@ -7,7 +7,7 @@
 
 3. [CURRENTLY SKIPPED] Bump all the packages to their latest versions by running `python scripts/update_package_versions.py`.
 
-4. Check the package upgrades are correct by running `aea check-packages`. Commit if satisfied.
+4. Check the package upgrades are correct by running `autonomy check-packages`. Commit if satisfied.
 
 5. Check the docs are up-to-date by running `python scripts/generate_api_documentation.py`. Ensure all links are configured `mkdocs serve`. Commit if satisfied.
 
@@ -28,7 +28,7 @@
 
 13. Build and tag images for the documentation. `skaffold build -p docs`. Inform DevOps of new release so that these images can be rolled out.
 
-14. Release packages into registry: `export OPEN_AEA_IPFS_ADDR="/dns/registry.autonolas.tech/tcp/443/https"`, `aea init --reset --author valory --ipfs --remote` and `aea push-all`. If necessary, run it several times until all packages are updated.
+14. Release packages into registry: `autonomy init --reset --author valory --ipfs --remote` and `autonomy push-all`. If necessary, run it several times until all packages are updated.
 
 15. Update the docker images via `skaffold build` and then, `export VERSION={new-version}` and `skaffold build -p docs`.
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -24,4 +24,4 @@ import autonomy
 
 def test_version() -> None:
     """Test the version."""
-    assert autonomy.__version__ == "0.1.1"
+    assert autonomy.__version__ == "0.1.2"


### PR DESCRIPTION
## Release summary

Version number: v0.1.2

## Release details

Autonomy:
- Updates `hash all` command to update agent hashes on service components when hashing service components
- Adds tests for missing coverage

Packages:
- Adds service for `hello_world` agent
- Introduces `raise_on_try` parameter in nested contract calls
- Introduces mechanism to enforce round id uniqueness
- Adds a method to clean the current period history for every parameter in the DB
- Adds parameter that users can optionally configure so period history is cleaned on every reset
- Fixes list representation in config YAML files
- Adds check for `unsafe-reset-all` to verify if the command exited successfully

Chores:
- Fixes `atheris` installation
- Adds CodeQL analysis

Docs:
- Adds documentation for `TendermintHandler` class
- Updates communication flows.
- Updates fonts and colours

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side), from `develop`
- [x] I've updated the dependencies versions to the latest, wherever is possible.
- [x] Lint and unit tests pass locally (please run tests also manually, not only with `tox`)
- [x] I built the documentation and updated it with the latest changes
- [x] I've added an item in `HISTORY.md` for this release
- [x] I bumped the version number in the `__init__.py` file.
- [ ] I published the latest version on TestPyPI and checked that the following command work:
       ```pip install project-name==<version-number> --index-url https://test.pypi.org/simple --force --no-cache-dir --no-deps```
- [ ] After merging the PR, I'll publish the build also on PyPI. Then, I'll make sure the following
      command will work:
      ```pip install project-name-template==<version_number> --force --no-cache-dir --no-deps```  
- [ ] After merging the PR, I'll tag the repo with `v${VERSION_NUMVER}` (e.g. `v0.1.2`)


