### PR TITLE
Feature/release v0.1.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ Describe your issue here.
 ### Your environment
 - OS: [e.g. iOS]
 - Python version: [e.g. 3.7.2]
-- Package Version [e.g. 0.1.2]
+- Package Version [e.g. 0.1.3]
 - Anything else you consider helpful.
 
 ### Steps to reproduce

--- a/.spelling
+++ b/.spelling
@@ -154,6 +154,17 @@ spookyswap
 config
 codeql
 os
+reusability
+autonolas
+sdks
+microservices
+protobuf
+multi-sig
+wei
+v1
+hardcoded
+e2e
+macos
  - docs/index.md
 README.md
 s_

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@ Autonomy:
 - Adds support for CID v1 hashes
 
 Packages:
-- Fixes `verify_contract` method to so it does not return a hardcoded value
+- Fixes `verify_contract` method so it does not return a hardcoded value
 - Replaces `history_duration` with `history_start`, `history_interval_in_unix` and `history_end` in APY skill.
 - Bumps the service registry contract to the latest version
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@ Autonomy:
 - Adds support for CID v1 hashes
 
 Packages:
-- Fixs `verify_contract` method to so it does not return a hardcoded value
+- Fixes `verify_contract` method to so it does not return a hardcoded value
 - Replaces `history_duration` with `history_start`, `history_interval_in_unix` and `history_end` in APY skill.
 - Bumps the service registry contract to the latest version
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,23 @@
 # Release History - `open-autonomy`
 
 
+## 0.1.2 (2022-15-08)
+
+Autonomy:
+- Adds support for CID v1 hashes
+
+Packages:
+- Fixs `verify_contract` method to so it does not return a hardcoded value
+- Replaces `history_duration` with `history_start`, `history_interval_in_unix` and `history_end` in APY skill.
+- Bumps the service registry contract to the latest version
+
+Chores:
+- Fixes the persistent peers' configurations for the e2e tests.
+- Updates ACN nodes in agent config files
+- Fixes tendermint subprocess termination issues on macOS
+- Fixes several flaky tests
+
+
 ## 0.1.2 (2022-07-08)
 
 Autonomy:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # Release History - `open-autonomy`
 
 
-## 0.1.2 (2022-15-08)
+## 0.1.3 (2022-15-08)
 
 Autonomy:
 - Adds support for CID v1 hashes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-autonomy` are currently being 
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `0.1.2`   | :white_check_mark: |
-| `< 0.1.2` | :x:                |
+| `0.1.3`   | :white_check_mark: |
+| `< 0.1.3` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/autonomy/__version__.py
+++ b/autonomy/__version__.py
@@ -22,7 +22,7 @@
 __title__ = "open-autonomy"
 __description__ = "A framework for the creation of autonomous agent services."
 __url__ = "https://github.com/valory-xyz/open-autonomy.git"
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021-2022 Valory AG"

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -5,6 +5,11 @@ Below we describe the additional manual steps required to upgrade between differ
 
 # Open Autonomy
 
+
+## `v0.1.2` to `v0.1.3`
+
+This release introduces the usage of CID v1 hashes.
+
 ## `v0.1.1` to `v0.1.2`
 
 No backwards incompatible changes

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -24,4 +24,4 @@ import autonomy
 
 def test_version() -> None:
     """Test the version."""
-    assert autonomy.__version__ == "0.1.2"
+    assert autonomy.__version__ == "0.1.3"


### PR DESCRIPTION
## Release summary

Version number: 0.1.3

## Release details

Autonomy:
- Adds support for CID v1 hashes

Packages:
- Fixes `verify_contract` method to so it does not return a hardcoded value
- Replaces `history_duration` with `history_start`, `history_interval_in_unix` and `history_end` in APY skill.
- Bumps the service registry contract to the latest version

Chores:
- Fixes the persistent peers' configurations for the e2e tests.
- Updates ACN nodes in agent config files
- Fixes tendermint subprocess termination issues on macOS
- Fixes several flaky tests

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side), from `develop`
- [x] I've updated the dependencies versions to the latest, wherever is possible.
- [x] Lint and unit tests pass locally (please run tests also manually, not only with `tox`)
- [ ] I built the documentation and updated it with the latest changes
- [x] I've added an item in `HISTORY.md` for this release
- [x] I bumped the version number in the `__init__.py` file.
- [ ] I published the latest version on TestPyPI and checked that the following command work:
       ```pip install project-name==<version-number> --index-url https://test.pypi.org/simple --force --no-cache-dir --no-deps```
- [ ] After merging the PR, I'll publish the build also on PyPI. Then, I'll make sure the following
      command will work:
      ```pip install project-name-template==<version_number> --force --no-cache-dir --no-deps```  
- [ ] After merging the PR, I'll tag the repo with `v${VERSION_NUMVER}` (e.g. `v0.1.2`)