### PR TITLE
Registration skill should not be abstract for registration e2e tests

### DIFF
--- a/tests/test_agents/test_registration.py
+++ b/tests/test_agents/test_registration.py
@@ -75,6 +75,10 @@ class RegistrationStartUpTestConfig(
             "value": True,
         },
         {
+            "dotted_path": f"vendor.valory.skills.{PublicId.from_str(skill_package).name}.is_abstract",
+            "value": False,
+        },
+        {
             "dotted_path": f"{__args_prefix}.observation_interval",
             "value": 15,
         },


### PR DESCRIPTION
## Proposed changes

Registration startup tests only use the registration skill without chaining with other skills. Therefore, we need to set its `is_abstract` configuration to `False` in order to load its components, after https://github.com/valory-xyz/open-autonomy/pull/1084.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

n/a