### PR TITLE
Release v0.1.4

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -165,6 +165,10 @@ v1
 hardcoded
 e2e
 macos
+eg
+frontend
+onchain
+dict
  - docs/index.md
 README.md
 s_
@@ -274,6 +278,7 @@ i
  - HISTORY.md
 0.1.0rc1
 0.1.0rc2
+serializer
  - docs/control_flow.md
 EntryPoint
 StartA

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,11 +5,11 @@
 Autonomy:
 - Ports deployment resources as data files
 - Adds support for the usage of remote registry when building a service deployment
-- Updated the image build process
+- Updates the image build process
 
 Packages:
 - Makes Registration ABCI abstract
-- Add check to make sure FSM chaining only involve abstract skills
+- Adds check to make sure FSM chaining only involves abstract skills
 - Sets a deadline for dict serializer hypothesis test in order to resolve flakiness
 
 Docs:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,19 @@
 # Release History - `open-autonomy`
 
+# 0.1.4
+
+Autonomy:
+- Ports deployment resources as data files
+- Adds support for the usage of remote registry when building a service deployment
+- Updated the image build process
+
+Packages:
+- Makes Registration ABCI abstract
+- Add check to make sure FSM chaining only involve abstract skills
+- Sets a deadline for dict serializer hypothesis test in order to resolve flakiness
+
+Docs:
+- Adds docs on publishing packages
 
 ## 0.1.3 (2022-15-08)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # Release History - `open-autonomy`
 
-# 0.1.4
+# 0.1.4 (2022-20-08)
 
 Autonomy:
 - Ports deployment resources as data files

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-autonomy` are currently being 
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `0.1.3`   | :white_check_mark: |
-| `< 0.1.3` | :x:                |
+| `0.1.4`   | :white_check_mark: |
+| `< 0.1.4` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/autonomy/__version__.py
+++ b/autonomy/__version__.py
@@ -22,7 +22,7 @@
 __title__ = "open-autonomy"
 __description__ = "A framework for the creation of autonomous agent services."
 __url__ = "https://github.com/valory-xyz/open-autonomy.git"
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021-2022 Valory AG"

--- a/docs/package_publishing.md
+++ b/docs/package_publishing.md
@@ -35,7 +35,7 @@ The on-chain protocol form contains:
 - Dependencies of the component (i.e. other components)
 
 After all this details have been filled out and sent, the package will be registered on the on-chain protocol. The component
-owner will receive in his wallet an NFT that represents the ownsership of this component.
+owner will receive in his wallet an NFT that represents the ownership of this component.
 
 It is important to emphasize that two different pushes to IPFS have been
 performed up to this point: the first one, done by the developer to push the code and a second one done through the frontend to push the metadata (that contains the code hash itself).

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -5,6 +5,9 @@ Below we describe the additional manual steps required to upgrade between differ
 
 # Open Autonomy
 
+## `v0.1.3` to `v0.1.4`
+
+This release changes the build process for docker images and service deployments. Refer to documentation for more information.
 
 ## `v0.1.2` to `v0.1.3`
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -24,4 +24,4 @@ import autonomy
 
 def test_version() -> None:
     """Test the version."""
-    assert autonomy.__version__ == "0.1.3"
+    assert autonomy.__version__ == "0.1.4"


### PR DESCRIPTION
## Release summary

Version number: v0.1.4

## Release details

Autonomy:
- Ports deployment resources as data files
- Adds support for the usage of remote registry when building a service deployment
- Updated the image build process

Packages:
- Makes Registration ABCI abstract
- Add check to make sure FSM chaining only involve abstract skills
- Sets a deadline for dict serializer hypothesis test in order to resolve flakiness

Docs:
- Adds docs on publishing packages

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side), from `develop`
- [x] I've updated the dependencies versions to the latest, wherever is possible.
- [x] Lint and unit tests pass locally (please run tests also manually, not only with `tox`)
- [x] I built the documentation and updated it with the latest changes
- [x] I've added an item in `HISTORY.md` for this release
- [x] I bumped the version number in the `__init__.py` file.
- [ ] I published the latest version on TestPyPI and checked that the following command work:
       ```pip install project-name==<version-number> --index-url https://test.pypi.org/simple --force --no-cache-dir --no-deps```
- [ ] After merging the PR, I'll publish the build also on PyPI. Then, I'll make sure the following
      command will work:
      ```pip install project-name-template==<version_number> --force --no-cache-dir --no-deps```  
- [ ] After merging the PR, I'll tag the repo with `v${VERSION_NUMVER}` (e.g. `v0.1.2`)

