### PR TITLE
test: replace check string

### DIFF
--- a/tests/test_agents/test_registration.py
+++ b/tests/test_agents/test_registration.py
@@ -54,7 +54,7 @@ STRICT_CHECK_STRINGS = (
     log_messages.collection_complete.value,
     log_messages.request_update.value,
     log_messages.response_update.value,
-    "Entered in the 'finished_registration' round for period 0",
+    "local height == remote height; continuing execution...",
 )
 
 


### PR DESCRIPTION
## Proposed changes

The registration e2e tests sometimes fail. The issue is because of the way that we check if the test succeeded, and not because the test does not really succeed. We are checking the logs of the agent. However, if the execution reaches a degenerate round, then it starts looping and logging very fast the same exception. This results in the test not detecting the expected logs - probably because of a buffer filling - even though they have been logged, and falsely reporting the e2e test to have failed.

Therefore, we replace the check string with another one that happens a bit before reaching the degenerate round but still ensures that the test has succeeded.

However, this solution does not guarantee that the e2e test will not falsely report a failure again but decreases the chances.

Two more appropriate solutions would be to:
 1. Decrease the interval of checking the logs.
 2. Raise and stop the execution when a degenerate round is reached instead of looping.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

n/a