### PR TITLE
Increase `round_timeout_seconds` for the APY e2e tests

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -360,7 +360,7 @@ jobs:
         os: [ ubuntu-latest ]
         python-version: [ "3.10" ]
 
-    timeout-minutes: 100
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v2

--- a/tests/test_agents/test_apy_estimation_abci.py
+++ b/tests/test_agents/test_apy_estimation_abci.py
@@ -63,7 +63,7 @@ class BaseTestABCIAPYEstimationSkillNormalExecution(BaseTestEnd2EndExecution):
         {
             "dotted_path": f"{__args_prefix}.round_timeout_seconds",
             "value": 200,
-        }
+        },
     ]
 
 

--- a/tests/test_agents/test_apy_estimation_abci.py
+++ b/tests/test_agents/test_apy_estimation_abci.py
@@ -63,6 +63,7 @@ class BaseTestABCIAPYEstimationSkillNormalExecution(BaseTestEnd2EndExecution):
         {
             "dotted_path": f"{__args_prefix}.round_timeout_seconds",
             "value": 200,
+            "type_": "float",
         },
     ]
 

--- a/tests/test_agents/test_apy_estimation_abci.py
+++ b/tests/test_agents/test_apy_estimation_abci.py
@@ -59,6 +59,10 @@ class BaseTestABCIAPYEstimationSkillNormalExecution(BaseTestEnd2EndExecution):
         {
             "dotted_path": f"{__args_prefix}.ipfs_domain_name",
             "value": "/dns/localhost/tcp/5001/http",
+        },
+        {
+            "dotted_path": f"{__args_prefix}.round_timeout_seconds",
+            "value": 200,
         }
     ]
 


### PR DESCRIPTION
## Proposed changes

Increased the `round_timeout_seconds`, because the optimization occasionally times out.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

n/a