### PR TITLE
Release v0.1.6

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -171,6 +171,7 @@ onchain
 dict
 PrintMessage
 Goerli
+utils
  - docs/index.md
 README.md
 s_

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,23 @@
 # Release History - `open-autonomy`
 
+
+# 0.1.6 (2022-08-01)
+
+Autonomy:
+- Extracts generic test utils into `autonomy.test_tools`
+
+Packages:
+- Ports the tendermint GRPC package and test tools from `agent-academy-1` repo
+- Moves base test classes into `abstract_round_abci` skill package
+
+Chore:
+- Bumps `mistune` to `2.0.3`
+- Updates `skaffold` to latest version
+
+Docs:
+- Updates the demo section
+- Adds info about Docker Desktop on MacOS and Windows
+
 # 0.1.5 (2022-07-29)
 
 Autonomy:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ The following table shows which versions of `open-autonomy` are currently being 
 
 | Version   | Supported          |
 | --------- | ------------------ |
-| `0.1.5`   | :white_check_mark: |
-| `< 0.1.5` | :x:                |
+| `0.1.6`   | :white_check_mark: |
+| `< 0.1.6` | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/autonomy/__version__.py
+++ b/autonomy/__version__.py
@@ -22,7 +22,7 @@
 __title__ = "open-autonomy"
 __description__ = "A framework for the creation of autonomous agent services."
 __url__ = "https://github.com/valory-xyz/open-autonomy.git"
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __author__ = "Valory AG"
 __license__ = "Apache-2.0"
 __copyright__ = "2021-2022 Valory AG"

--- a/docs/simple_abci.md
+++ b/docs/simple_abci.md
@@ -20,7 +20,7 @@ The demo is composed of:
 - A set of $n$ Tendermint nodes.
 - A set of $n$ AEAs, in one-to-one connection with one Tendermint node.
 
-The agents are connected to the remote service [DRAND](https://drand.love) throught the Internet.
+The agents are connected to the remote service [DRAND](https://drand.love) through the Internet.
 
 <figure markdown>
   ![](./images/simple_abci_app_four_agents.svg){align=center}

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -5,6 +5,10 @@ Below we describe the additional manual steps required to upgrade between differ
 
 # Open Autonomy
 
+## `v0.1.5` to `v0.1.6`
+
+No backwards incompatible changes
+
 ## `v0.1.4` to `v0.1.5`
 
 No backwards incompatible changes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,22 @@ nav:
           - Agent: 'api/replay/agent.md'
           - Tendermint: 'api/replay/tendermint.md'
           - Utils: 'api/replay/utils.md'
+        - Test Tools:
+          - Configurations: api/test_tools/configurations.md
+          - Fixture Helpers: api/test_tools/fixture_helpers.md
+          - Agents: api/test_tools/base_test_classes/agents.md
+          - Contracts: api/test_tools/base_test_classes/contracts.md
+          - ACN Node: api/test_tools/docker/acn_node.md
+          - AMM Net: api/test_tools/docker/amm_net.md
+          - Base: api/test_tools/docker/base.md
+          - Ganache Helpers: api/test_tools/docker/ganache.md
+          - Gnosis Safe Helpers: api/test_tools/docker/gnosis_safe_net.md
+          - Tendermint Helpers: api/test_tools/docker/tendermint.md
+          - Helpers:
+            - Async Utils: api/test_tools/helpers/async_utils.md
+            - Base: api/test_tools/helpers/base.md
+            - Contracts: api/test_tools/helpers/contracts.md
+            - Tendermint Utils: api/test_tools/helpers/tendermint_utils.md
       - Connections:
         - ABCI:
           - Check Dependencies: 'api/connections/abci/check_dependencies.md'
@@ -124,6 +140,9 @@ nav:
           - Dialogues: 'api/skills/abstract_round_abci/dialogues.md'
           - Handlers: 'api/skills/abstract_round_abci/handlers.md'
           - Models: 'api/skills/abstract_round_abci/models.md'
+          - Test Tools:
+            - Base: api/skills/abstract_round_abci/test_tools/base.md
+            - Integration: api/skills/abstract_round_abci/test_tools/integration.md
           - IO:
             - IPFS: 'api/skills/abstract_round_abci/io/ipfs.md'
             - Load: 'api/skills/abstract_round_abci/io/load.md'
@@ -136,6 +155,8 @@ nav:
           - Models: 'api/skills/oracle_deployment_abci/models.md'
           - Payloads: 'api/skills/oracle_deployment_abci/payloads.md'
           - Rounds: 'api/skills/oracle_deployment_abci/rounds.md'
+          - Dialogues: api/skills/oracle_deployment_abci/dialogues.md
+          - Handlers: api/skills/oracle_deployment_abci/handlers.md
         - Price Estimation ABCI:
           - Behaviours: 'api/skills/price_estimation_abci/behaviours.md'
           - Dialogues: 'api/skills/price_estimation_abci/dialogues.md'
@@ -144,19 +165,33 @@ nav:
           - Payloads: 'api/skills/price_estimation_abci/payloads.md'
           - Rounds: 'api/skills/price_estimation_abci/rounds.md'
         - Oracle ABCI:
+          - Behaviours: api/skills/oracle_abci/behaviours.md
           - Composition: 'api/skills/oracle_abci/composition.md'
+          - Dialogues: api/skills/oracle_abci/dialogues.md
+          - Handlers: api/skills/oracle_abci/handlers.md
+          - Models: api/skills/oracle_abci/models.md
         - Registration ABCI:
           - Behaviours: 'api/skills/registration_abci/behaviours.md'
           - Payloads: 'api/skills/registration_abci/payloads.md'
           - Rounds: 'api/skills/registration_abci/rounds.md'
+          - Dialogues: api/skills/registration_abci/dialogues.md
+          - Handlers: api/skills/registration_abci/handlers.md
+          - Models: api/skills/registration_abci/models.md
         - Safe Deployment ABCI:
           - Behaviours: 'api/skills/safe_deployment_abci/behaviours.md'
           - Payloads: 'api/skills/safe_deployment_abci/payloads.md'
           - Rounds: 'api/skills/safe_deployment_abci/rounds.md'
+          - Dialogues: api/skills/safe_deployment_abci/dialogues.md
+          - Handlers: api/skills/safe_deployment_abci/handlers.md
+          - Models: api/skills/safe_deployment_abci/models.md
         - Transaction Settlement ABCI:
           - Behaviours: 'api/skills/transaction_settlement_abci/behaviours.md'
           - Payloads: 'api/skills/transaction_settlement_abci/payloads.md'
           - Rounds: 'api/skills/transaction_settlement_abci/rounds.md'
+          - Dialogues: api/skills/transaction_settlement_abci/dialogues.md
+          - Handlers: api/skills/transaction_settlement_abci/handlers.md
+          - Models: api/skills/transaction_settlement_abci/models.md
+          - Payload Tools: api/skills/transaction_settlement_abci/payload_tools.md
       - Exceptions: exceptions.md
   - Miscellaneous:
     - Ethereum: 'ethereum_specifics.md'

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -24,4 +24,4 @@ import autonomy
 
 def test_version() -> None:
     """Test the version."""
-    assert autonomy.__version__ == "0.1.5"
+    assert autonomy.__version__ == "0.1.6"


### PR DESCRIPTION
## Release summary

Version number: v0.1.6 

## Release details

Autonomy:
- Extracts generic test utils into `autonomy.test_tools`

Packages:
- Ports the tendermint GRPC package and test tools from `agent-academy-1` repo
- Moves base test classes into `abstract_round_abci` skill package

Chore:
- Bumps `mistune` to `2.0.3`
- Updates `skaffold` to latest version

Docs:
- Updates the demo section
- Adds info about Docker Desktop on MacOS and Windows

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side), from `develop`
- [x] I've updated the dependencies versions to the latest, wherever is possible.
- [x] Lint and unit tests pass locally (please run tests also manually, not only with `tox`)
- [x] I built the documentation and updated it with the latest changes
- [x] I've added an item in `HISTORY.md` for this release
- [x] I bumped the version number in the `__init__.py` file.
- [ ] I published the latest version on TestPyPI and checked that the following command work:
       ```pip install project-name==<version-number> --index-url https://test.pypi.org/simple --force --no-cache-dir --no-deps```
- [ ] After merging the PR, I'll publish the build also on PyPI. Then, I'll make sure the following
      command will work:
      ```pip install project-name-template==<version_number> --force --no-cache-dir --no-deps```  
- [ ] After merging the PR, I'll tag the repo with `v${VERSION_NUMVER}` (e.g. `v0.1.2`)


## Further comments

Write here any other comment about the release, if any.
