### PR TITLE
Add flags to specify dev-mode directories on build command

### DIFF
--- a/autonomy/cli/deploy.py
+++ b/autonomy/cli/deploy.py
@@ -108,6 +108,19 @@ def deploy_group(
     default=False,
     help="Remove existing build and overwrite with new one.",
 )
+@click.option(
+    "--packages-dir", type=click.Path(), help="Path to packages dir (Use with dev mode)"
+)
+@click.option(
+    "--open-aea-dir",
+    type=click.Path(),
+    help="Path to open-aea repo (Use with dev mode)",
+)
+@click.option(
+    "--open-autonomy-dir",
+    type=click.Path(),
+    help="Path to open-autonomy repo (Use with dev mode)",
+)
 @registry_flag()
 @password_option(confirmation_prompt=True)
 @click.pass_context
@@ -122,11 +135,19 @@ def build_deployment_command(  # pylint: disable=too-many-arguments, too-many-lo
     number_of_agents: Optional[int] = None,
     password: Optional[str] = None,
     version: Optional[str] = None,
+    open_aea_dir: Optional[Path] = None,
+    packages_dir: Optional[Path] = None,
+    open_autonomy_dir: Optional[Path] = None,
 ) -> None:
     """Build deployment setup for n agents."""
 
     keys_file = Path(keys_file or DEFAULT_KEYS_FILE).absolute()
     build_dir = Path(output_dir or DEFAULT_ABCI_BUILD_DIR).absolute()
+    packages_dir = Path(packages_dir or Path.cwd() / "packages").absolute()
+    open_aea_dir = Path(open_aea_dir or Path.home() / "open-aea").absolute()
+    open_autonomy_dir = Path(
+        open_autonomy_dir or Path.home() / "open-autonomy"
+    ).absolute()
 
     ctx = cast(Context, click_context.obj)
     ctx.registry_type = registry
@@ -141,6 +162,9 @@ def build_deployment_command(  # pylint: disable=too-many-arguments, too-many-lo
             number_of_agents,
             password,
             version,
+            packages_dir,
+            open_aea_dir,
+            open_autonomy_dir,
         )
     except Exception as e:  # pylint: disable=broad-except
         shutil.rmtree(build_dir)
@@ -287,6 +311,9 @@ def build_deployment(  # pylint: disable=too-many-arguments
     number_of_agents: Optional[int] = None,
     password: Optional[str] = None,
     version: Optional[str] = None,
+    packages_dir: Optional[Path] = None,
+    open_aea_dir: Optional[Path] = None,
+    open_autonomy_dir: Optional[Path] = None,
 ) -> None:
     """Build deployment."""
     if build_dir.is_dir():
@@ -307,6 +334,9 @@ def build_deployment(  # pylint: disable=too-many-arguments
         build_dir=build_dir,
         dev_mode=dev_mode,
         version=version,
+        packages_dir=packages_dir,
+        open_aea_dir=open_aea_dir,
+        open_autonomy_dir=open_autonomy_dir,
     )
     click.echo(report)
 

--- a/autonomy/deploy/base.py
+++ b/autonomy/deploy/base.py
@@ -148,19 +148,33 @@ class BaseDeploymentGenerator:
     build_dir: Path
     output: str
     tendermint_job_config: Optional[str]
+    dev_mode: bool
+    packages_dir: Path
+    open_aea_dir: Path
+    open_autonomy_dir: Path
 
-    def __init__(self, service_spec: ServiceSpecification, build_dir: Path):
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        service_spec: ServiceSpecification,
+        build_dir: Path,
+        dev_mode: bool = False,
+        packages_dir: Optional[Path] = None,
+        open_aea_dir: Optional[Path] = None,
+        open_autonomy_dir: Optional[Path] = None,
+    ):
         """Initialise with only kwargs."""
         self.service_spec = service_spec
         self.build_dir = Path(build_dir)
         self.tendermint_job_config: Optional[str] = None
+        self.dev_mode = dev_mode
+        self.packages_dir = packages_dir or Path.cwd().absolute() / "packages"
+        self.open_aea_dir = open_aea_dir or Path.home().absolute() / "open-aea"
+        self.open_autonomy_dir = (
+            open_autonomy_dir or Path.home().absolute() / "open-autonomy"
+        )
 
     @abc.abstractmethod
-    def generate(
-        self,
-        image_versions: Dict[str, str],
-        dev_mode: bool = False,
-    ) -> "BaseDeploymentGenerator":
+    def generate(self, image_versions: Dict[str, str]) -> "BaseDeploymentGenerator":
         """Generate the deployment configuration."""
 
     @abc.abstractmethod

--- a/autonomy/deploy/build.py
+++ b/autonomy/deploy/build.py
@@ -46,6 +46,9 @@ def generate_deployment(  # pylint: disable=too-many-arguments
     private_keys_password: Optional[str] = None,
     dev_mode: bool = False,
     version: Optional[str] = None,
+    packages_dir: Optional[Path] = None,
+    open_aea_dir: Optional[Path] = None,
+    open_autonomy_dir: Optional[Path] = None,
 ) -> str:
     """Generate the deployment build for the valory app."""
 
@@ -74,10 +77,17 @@ def generate_deployment(  # pylint: disable=too-many-arguments
         raise ValueError(f"Cannot find deployment generator for {type_of_deployment}")
     deployment = cast(
         BaseDeploymentGenerator,
-        DeploymentGenerator(service_spec=service_spec, build_dir=build_dir),
+        DeploymentGenerator(
+            service_spec=service_spec,
+            build_dir=build_dir,
+            dev_mode=dev_mode,
+            packages_dir=packages_dir,
+            open_aea_dir=open_aea_dir,
+            open_autonomy_dir=open_autonomy_dir,
+        ),
     )
 
-    deployment.generate(image_versions, dev_mode).generate_config_tendermint(
+    deployment.generate(image_versions).generate_config_tendermint(
         image_versions["tendermint"]
     ).write_config().populate_private_keys()
 

--- a/autonomy/deploy/generators/docker_compose/base.py
+++ b/autonomy/deploy/generators/docker_compose/base.py
@@ -71,7 +71,8 @@ def build_agent_config(  # pylint: disable=too-many-arguments
     agent_vars: Dict,
     dev_mode: bool = False,
     package_dir: Path = Path.cwd().absolute() / "packages",
-    open_aea_dir: Path = Path.cwd().absolute().parent / "open-aea",
+    open_aea_dir: Path = Path.home().absolute() / "open-aea",
+    open_autonomy_dir: Path = Path.home().absolute() / "open-autonomy",
     open_aea_image_name: str = OPEN_AEA_IMAGE_NAME,
     open_aea_image_version: str = IMAGE_VERSION,
 ) -> str:
@@ -93,6 +94,7 @@ def build_agent_config(  # pylint: disable=too-many-arguments
         )
         config += f"      - {package_dir}:/home/ubuntu/packages:rw\n"
         config += f"      - {open_aea_dir}:/open-aea\n"
+        config += f"      - {open_autonomy_dir}:/open-autonomy\n"
 
     return config
 
@@ -152,14 +154,13 @@ class DockerComposeGenerator(BaseDeploymentGenerator):
     def generate(
         self,
         image_versions: Dict[str, str],
-        dev_mode: bool = False,
     ) -> "DockerComposeGenerator":
         """Generate the new configuration."""
 
         agent_vars = self.service_spec.generate_agents()
         image_name = self.service_spec.service.agent.name
 
-        if dev_mode:
+        if self.dev_mode:
             image_versions["agent"] = "dev"
 
         agents = "".join(
@@ -169,15 +170,20 @@ class DockerComposeGenerator(BaseDeploymentGenerator):
                     i,
                     self.service_spec.service.number_of_agents,
                     agent_vars[i],
-                    dev_mode,
+                    self.dev_mode,
                     open_aea_image_version=image_versions["agent"],
+                    package_dir=self.packages_dir,
+                    open_aea_dir=self.open_aea_dir,
+                    open_autonomy_dir=self.open_autonomy_dir,
                 )
                 for i in range(self.service_spec.service.number_of_agents)
             ]
         )
         tendermint_nodes = "".join(
             [
-                build_tendermint_node_config(i, dev_mode, image_versions["tendermint"])
+                build_tendermint_node_config(
+                    i, self.dev_mode, image_versions["tendermint"]
+                )
                 for i in range(self.service_spec.service.number_of_agents)
             ]
         )

--- a/autonomy/deploy/generators/kubernetes/base.py
+++ b/autonomy/deploy/generators/kubernetes/base.py
@@ -21,7 +21,7 @@
 """Script to create environment for benchmarking n agents."""
 
 from pathlib import Path
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
 
 import yaml
 
@@ -52,9 +52,24 @@ class KubernetesGenerator(BaseDeploymentGenerator):
     output_name: str = "build.yaml"
     deployment_type: str = "kubernetes"
 
-    def __init__(self, service_spec: ServiceSpecification, build_dir: Path) -> None:
+    def __init__(
+        self,
+        service_spec: ServiceSpecification,
+        build_dir: Path,
+        dev_mode: bool = False,
+        packages_dir: Optional[Path] = None,
+        open_aea_dir: Optional[Path] = None,
+        open_autonomy_dir: Optional[Path] = None,
+    ) -> None:
         """Initialise the deployment generator."""
-        super().__init__(service_spec, build_dir)
+        super().__init__(
+            service_spec,
+            build_dir,
+            dev_mode,
+            packages_dir,
+            open_aea_dir,
+            open_autonomy_dir,
+        )
         self.resources: List[str] = []
 
     def build_agent_deployment(
@@ -132,11 +147,10 @@ class KubernetesGenerator(BaseDeploymentGenerator):
     def generate(  # pylint: disable=unused-argument
         self,
         image_versions: Dict[str, str],
-        dev_mode: bool = False,
     ) -> "KubernetesGenerator":
         """Generate the deployment."""
 
-        if dev_mode:
+        if self.dev_mode:
             self.resources.append(
                 HARDHAT_TEMPLATE % (HARDHAT_IMAGE_NAME, image_versions["hardhat"])
             )

--- a/autonomy/deploy/generators/kubernetes/base.py
+++ b/autonomy/deploy/generators/kubernetes/base.py
@@ -52,7 +52,7 @@ class KubernetesGenerator(BaseDeploymentGenerator):
     output_name: str = "build.yaml"
     deployment_type: str = "kubernetes"
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         service_spec: ServiceSpecification,
         build_dir: Path,

--- a/docs/api/cli/deploy.md
+++ b/docs/api/cli/deploy.md
@@ -68,10 +68,23 @@ Deploy an agent service.
     default=False,
     help="Remove existing build and overwrite with new one.",
 )
+@click.option(
+    "--packages-dir", type=click.Path(), help="Path to packages dir (Use with dev mode)"
+)
+@click.option(
+    "--open-aea-dir",
+    type=click.Path(),
+    help="Path to open-aea repo (Use with dev mode)",
+)
+@click.option(
+    "--open-autonomy-dir",
+    type=click.Path(),
+    help="Path to open-autonomy repo (Use with dev mode)",
+)
 @registry_flag()
 @password_option(confirmation_prompt=True)
 @click.pass_context
-def build_deployment_command(click_context: click.Context, keys_file: Optional[Path], deployment_type: str, output_dir: Optional[Path], dev_mode: bool, force_overwrite: bool, registry: str, number_of_agents: Optional[int] = None, password: Optional[str] = None, version: Optional[str] = None) -> None
+def build_deployment_command(click_context: click.Context, keys_file: Optional[Path], deployment_type: str, output_dir: Optional[Path], dev_mode: bool, force_overwrite: bool, registry: str, number_of_agents: Optional[int] = None, password: Optional[str] = None, version: Optional[str] = None, open_aea_dir: Optional[Path] = None, packages_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None) -> None
 ```
 
 Build deployment setup for n agents.
@@ -145,7 +158,7 @@ Run service deployment.
 #### build`_`deployment
 
 ```python
-def build_deployment(keys_file: Path, build_dir: Path, deployment_type: str, dev_mode: bool, force_overwrite: bool, number_of_agents: Optional[int] = None, password: Optional[str] = None, version: Optional[str] = None) -> None
+def build_deployment(keys_file: Path, build_dir: Path, deployment_type: str, dev_mode: bool, force_overwrite: bool, number_of_agents: Optional[int] = None, password: Optional[str] = None, version: Optional[str] = None, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None) -> None
 ```
 
 Build deployment.

--- a/docs/api/deploy/base.md
+++ b/docs/api/deploy/base.md
@@ -89,7 +89,7 @@ Base Deployment Class.
 #### `__`init`__`
 
 ```python
-def __init__(service_spec: ServiceSpecification, build_dir: Path)
+def __init__(service_spec: ServiceSpecification, build_dir: Path, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None)
 ```
 
 Initialise with only kwargs.
@@ -100,7 +100,7 @@ Initialise with only kwargs.
 
 ```python
 @abc.abstractmethod
-def generate(image_versions: Dict[str, str], dev_mode: bool = False) -> "BaseDeploymentGenerator"
+def generate(image_versions: Dict[str, str]) -> "BaseDeploymentGenerator"
 ```
 
 Generate the deployment configuration.

--- a/docs/api/deploy/build.md
+++ b/docs/api/deploy/build.md
@@ -9,7 +9,7 @@ Script for generating deployment environments.
 #### generate`_`deployment
 
 ```python
-def generate_deployment(type_of_deployment: str, private_keys_file_path: Path, service_path: Path, build_dir: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, dev_mode: bool = False, version: Optional[str] = None) -> str
+def generate_deployment(type_of_deployment: str, private_keys_file_path: Path, service_path: Path, build_dir: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, dev_mode: bool = False, version: Optional[str] = None, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None) -> str
 ```
 
 Generate the deployment build for the valory app.

--- a/docs/api/deploy/generators/docker_compose/base.md
+++ b/docs/api/deploy/generators/docker_compose/base.md
@@ -19,7 +19,7 @@ Build tendermint node config for docker compose.
 #### build`_`agent`_`config
 
 ```python
-def build_agent_config(valory_app: str, node_id: int, number_of_agents: int, agent_vars: Dict, dev_mode: bool = False, package_dir: Path = Path.cwd().absolute() / "packages", open_aea_dir: Path = Path.cwd().absolute().parent / "open-aea", open_aea_image_name: str = OPEN_AEA_IMAGE_NAME, open_aea_image_version: str = IMAGE_VERSION) -> str
+def build_agent_config(valory_app: str, node_id: int, number_of_agents: int, agent_vars: Dict, dev_mode: bool = False, package_dir: Path = Path.cwd().absolute() / "packages", open_aea_dir: Path = Path.home().absolute() / "open-aea", open_autonomy_dir: Path = Path.home().absolute() / "open-autonomy", open_aea_image_name: str = OPEN_AEA_IMAGE_NAME, open_aea_image_version: str = IMAGE_VERSION) -> str
 ```
 
 Build agent config.
@@ -49,7 +49,7 @@ Generate the command to configure tendermint testnet.
 #### generate
 
 ```python
-def generate(image_versions: Dict[str, str], dev_mode: bool = False) -> "DockerComposeGenerator"
+def generate(image_versions: Dict[str, str]) -> "DockerComposeGenerator"
 ```
 
 Generate the new configuration.

--- a/docs/api/deploy/generators/kubernetes/base.md
+++ b/docs/api/deploy/generators/kubernetes/base.md
@@ -19,7 +19,7 @@ Kubernetes Deployment Generator.
 #### `__`init`__`
 
 ```python
-def __init__(service_spec: ServiceSpecification, build_dir: Path) -> None
+def __init__(service_spec: ServiceSpecification, build_dir: Path, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None) -> None
 ```
 
 Initialise the deployment generator.
@@ -49,7 +49,7 @@ Build configuration job.
 #### generate
 
 ```python
-def generate(image_versions: Dict[str, str], dev_mode: bool = False) -> "KubernetesGenerator"
+def generate(image_versions: Dict[str, str]) -> "KubernetesGenerator"
 ```
 
 Generate the deployment.

--- a/docs/autonomy.md
+++ b/docs/autonomy.md
@@ -24,18 +24,21 @@ Usage: autonomy deploy build [OPTIONS] [KEYS_FILE]
   Build deployment setup for n agents.
 
 Options:
-  --o PATH             Path to output dir.
-  --n INTEGER          Number of agents.
-  --docker             Use docker as a backend.
-  --kubernetes         Use kubernetes as a backend.
-  --dev                Create development environment.
-  --version TEXT       Specify deployment version.
-  --force              Remove existing build and overwrite with new one.
-  --remote             To use a remote registry.
-  --local              To use a local registry.
-  -p                   Ask for password interactively
-  --password PASSWORD  Set password for key encryption/decryption
-  --help               Show this message and exit.
+  --o PATH                  Path to output dir.
+  --n INTEGER               Number of agents.
+  --docker                  Use docker as a backend.
+  --kubernetes              Use kubernetes as a backend.
+  --dev                     Create development environment.
+  --version TEXT            Specify deployment version.
+  --force                   Remove existing build and overwrite with new one.
+  --packages-dir PATH       Path to packages dir (Use with dev mode)
+  --open-aea-dir PATH       Path to open-aea repo (Use with dev mode)
+  --open-autonomy-dir PATH  Path to open-autonomy repo (Use with dev mode)
+  --remote                  To use a remote registry.
+  --local                   To use a local registry.
+  -p                        Ask for password interactively
+  --password PASSWORD       Set password for key encryption/decryption
+  --help                    Show this message and exit.
 ```
 
 To create an environment you'll need a service and a file containing keys with funds for the chain you want to use. The necessary images will be built during the build process.

--- a/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
@@ -71,7 +71,7 @@ class TestFromToken(BaseCliTest):
                 "Building service deployment using token ID: 2"
                 in click_mock.call_args_list[0][0][0]
             )
-            assert "Service name: Hello World" in click_mock.call_args_list[1][0][0]
+            assert "Service name: " in click_mock.call_args_list[1][0][0]
             assert (
                 "Downloaded service package valory/hello_world:0.1.0"
                 in click_mock.call_args_list[2][0][0]


### PR DESCRIPTION
## Proposed changes

This PR update the `autonomy deploy build` command to re-enable the dev mode

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my change
