### PR TITLE
Enable env vars usage on service configs

### DIFF
--- a/autonomy/cli/deploy.py
+++ b/autonomy/cli/deploy.py
@@ -127,6 +127,12 @@ def deploy_group(
     type=click.Path(),
     help="Path to open-autonomy repo (Use with dev mode)",
 )
+@click.option(
+    "--aev",
+    is_flag=True,
+    default=False,
+    help="Apply environment variable when loading service config.",
+)
 @registry_flag()
 @password_option(confirmation_prompt=True)
 @click.pass_context
@@ -144,6 +150,7 @@ def build_deployment_command(  # pylint: disable=too-many-arguments, too-many-lo
     packages_dir: Optional[Path] = None,
     open_autonomy_dir: Optional[Path] = None,
     log_level: str = INFO,
+    aev: bool = False,
 ) -> None:
     """Build deployment setup for n agents."""
 
@@ -171,6 +178,7 @@ def build_deployment_command(  # pylint: disable=too-many-arguments, too-many-lo
             open_aea_dir,
             open_autonomy_dir,
             log_level=log_level,
+            substitute_env_vars=aev,
         )
     except Exception as e:  # pylint: disable=broad-except
         shutil.rmtree(build_dir)
@@ -212,6 +220,12 @@ def run(build_dir: Path, no_recreate: bool, remove_orphans: bool) -> None:
 )
 @click.option("--n", type=int, help="Number of agents to include in the build.")
 @click.option("--skip-image", is_flag=True, default=False, help="Skip building images.")
+@click.option(
+    "--aev",
+    is_flag=True,
+    default=False,
+    help="Apply environment variable when loading service config.",
+)
 @chain_selection_flag()
 @click.pass_context
 def run_deployment_from_token(  # pylint: disable=too-many-arguments, too-many-locals
@@ -223,6 +237,7 @@ def run_deployment_from_token(  # pylint: disable=too-many-arguments, too-many-l
     service_contract_address: Optional[str],
     skip_image: bool,
     n: Optional[int],
+    aev: bool = False,
 ) -> None:
     """Run service deployment."""
 
@@ -243,7 +258,7 @@ def run_deployment_from_token(  # pylint: disable=too-many-arguments, too-many-l
     build_dir = service_path / DEFAULT_ABCI_BUILD_DIR
 
     update_multisig_address(service_path, multisig_address)
-    service = load_service_config(service_path)
+    service = load_service_config(service_path, substitute_env_vars=aev)
 
     with cd(service_path):
         if not skip_image:
@@ -258,6 +273,7 @@ def run_deployment_from_token(  # pylint: disable=too-many-arguments, too-many-l
             force_overwrite=True,
             number_of_agents=n,
             agent_instances=agent_instances,
+            substitute_env_vars=aev,
         )
 
     click.echo("Service build successful.")
@@ -295,6 +311,7 @@ def build_deployment(  # pylint: disable=too-many-arguments
     open_autonomy_dir: Optional[Path] = None,
     agent_instances: Optional[List[str]] = None,
     log_level: str = INFO,
+    substitute_env_vars: bool = False,
 ) -> None:
     """Build deployment."""
     if build_dir.is_dir():
@@ -319,6 +336,7 @@ def build_deployment(  # pylint: disable=too-many-arguments
         open_autonomy_dir=open_autonomy_dir,
         agent_instances=agent_instances,
         log_level=log_level,
+        substitute_env_vars=substitute_env_vars,
     )
     click.echo(report)
 

--- a/autonomy/configurations/loader.py
+++ b/autonomy/configurations/loader.py
@@ -19,16 +19,19 @@
 
 """Service component base."""
 
+import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, cast
 
-import yaml
 from aea.configurations.base import (
     ConnectionConfig,
     ContractConfig,
     ProtocolConfig,
     SkillConfig,
 )
+from aea.helpers.env_vars import apply_env_variables
+from aea.helpers.io import open_file
+from aea.helpers.yaml_utils import yaml_load_all
 
 from autonomy.configurations.base import Service
 
@@ -44,14 +47,20 @@ COMPONENT_CONFIGS: Dict = {
 }
 
 
-def load_service_config(service_path: Path) -> Service:
+def load_service_config(
+    service_path: Path, substitute_env_vars: bool = False
+) -> Service:
     """Load service config from the path."""
 
-    with open(
+    with open_file(
         service_path / Service.default_configuration_filename, "r", encoding="utf-8"
     ) as fp:
-        service_config, *overrides = yaml.load_all(fp, Loader=yaml.SafeLoader)
+        data = yaml_load_all(fp)
 
+    if substitute_env_vars:
+        data = cast(List[Dict], apply_env_variables(data, env_variables=os.environ))
+
+    service_config, *overrides = data
     Service.validate_config_data(service_config)
     service_config["license_"] = service_config.pop("license")
 

--- a/autonomy/deploy/base.py
+++ b/autonomy/deploy/base.py
@@ -70,11 +70,14 @@ class ServiceSpecification:
         private_keys_password: Optional[str] = None,
         agent_instances: Optional[List[str]] = None,
         log_level: str = INFO,
+        substitute_env_vars: bool = False,
     ) -> None:
         """Initialize the Base Deployment."""
         self.keys: List = []
         self.private_keys_password = private_keys_password
-        self.service = load_service_config(service_path)
+        self.service = load_service_config(
+            service_path, substitute_env_vars=substitute_env_vars
+        )
         self.log_level = log_level
 
         # we allow configurable number of agents independent of the

--- a/autonomy/deploy/build.py
+++ b/autonomy/deploy/build.py
@@ -45,6 +45,7 @@ def generate_deployment(  # pylint: disable=too-many-arguments, too-many-locals
     open_autonomy_dir: Optional[Path] = None,
     agent_instances: Optional[List[str]] = None,
     log_level: str = INFO,
+    substitute_env_vars: bool = False,
 ) -> str:
     """Generate the deployment build for the valory app."""
 
@@ -55,6 +56,7 @@ def generate_deployment(  # pylint: disable=too-many-arguments, too-many-locals
         number_of_agents=number_of_agents,
         agent_instances=agent_instances,
         log_level=log_level,
+        substitute_env_vars=substitute_env_vars,
     )
 
     DeploymentGenerator = DEPLOYMENT_OPTIONS.get(type_of_deployment)

--- a/docs/api/cli/deploy.md
+++ b/docs/api/cli/deploy.md
@@ -82,10 +82,16 @@ Deploy an agent service.
     type=click.Path(),
     help="Path to open-autonomy repo (Use with dev mode)",
 )
+@click.option(
+    "--aev",
+    is_flag=True,
+    default=False,
+    help="Apply environment variable when loading service config.",
+)
 @registry_flag()
 @password_option(confirmation_prompt=True)
 @click.pass_context
-def build_deployment_command(click_context: click.Context, keys_file: Optional[Path], deployment_type: str, output_dir: Optional[Path], dev_mode: bool, force_overwrite: bool, registry: str, number_of_agents: Optional[int] = None, password: Optional[str] = None, open_aea_dir: Optional[Path] = None, packages_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, log_level: str = INFO) -> None
+def build_deployment_command(click_context: click.Context, keys_file: Optional[Path], deployment_type: str, output_dir: Optional[Path], dev_mode: bool, force_overwrite: bool, registry: str, number_of_agents: Optional[int] = None, password: Optional[str] = None, open_aea_dir: Optional[Path] = None, packages_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, log_level: str = INFO, aev: bool = False) -> None
 ```
 
 Build deployment setup for n agents.
@@ -134,9 +140,15 @@ Run deployment.
 )
 @click.option("--n", type=int, help="Number of agents to include in the build.")
 @click.option("--skip-image", is_flag=True, default=False, help="Skip building images.")
+@click.option(
+    "--aev",
+    is_flag=True,
+    default=False,
+    help="Apply environment variable when loading service config.",
+)
 @chain_selection_flag()
 @click.pass_context
-def run_deployment_from_token(click_context: click.Context, token_id: int, keys_file: Path, chain_type: str, rpc_url: Optional[str], service_contract_address: Optional[str], skip_image: bool, n: Optional[int]) -> None
+def run_deployment_from_token(click_context: click.Context, token_id: int, keys_file: Path, chain_type: str, rpc_url: Optional[str], service_contract_address: Optional[str], skip_image: bool, n: Optional[int], aev: bool = False) -> None
 ```
 
 Run service deployment.
@@ -156,7 +168,7 @@ Update the multisig address on the service config.
 #### build`_`deployment
 
 ```python
-def build_deployment(keys_file: Path, build_dir: Path, deployment_type: str, dev_mode: bool, force_overwrite: bool, number_of_agents: Optional[int] = None, password: Optional[str] = None, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, log_level: str = INFO) -> None
+def build_deployment(keys_file: Path, build_dir: Path, deployment_type: str, dev_mode: bool, force_overwrite: bool, number_of_agents: Optional[int] = None, password: Optional[str] = None, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, log_level: str = INFO, substitute_env_vars: bool = False) -> None
 ```
 
 Build deployment.

--- a/docs/api/configurations/loader.md
+++ b/docs/api/configurations/loader.md
@@ -9,7 +9,7 @@ Service component base.
 #### load`_`service`_`config
 
 ```python
-def load_service_config(service_path: Path) -> Service
+def load_service_config(service_path: Path, substitute_env_vars: bool = False) -> Service
 ```
 
 Load service config from the path.

--- a/docs/api/deploy/base.md
+++ b/docs/api/deploy/base.md
@@ -19,7 +19,7 @@ Class to assist with generating deployments.
 #### `__`init`__`
 
 ```python
-def __init__(service_path: Path, keys: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, agent_instances: Optional[List[str]] = None, log_level: str = INFO) -> None
+def __init__(service_path: Path, keys: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, agent_instances: Optional[List[str]] = None, log_level: str = INFO, substitute_env_vars: bool = False) -> None
 ```
 
 Initialize the Base Deployment.

--- a/docs/api/deploy/build.md
+++ b/docs/api/deploy/build.md
@@ -9,7 +9,7 @@ Script for generating deployment environments.
 #### generate`_`deployment
 
 ```python
-def generate_deployment(type_of_deployment: str, private_keys_file_path: Path, service_path: Path, build_dir: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, log_level: str = INFO) -> str
+def generate_deployment(type_of_deployment: str, private_keys_file_path: Path, service_path: Path, build_dir: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, log_level: str = INFO, substitute_env_vars: bool = False) -> str
 ```
 
 Generate the deployment build for the valory app.

--- a/tests/test_autonomy/test_configurations.py
+++ b/tests/test_autonomy/test_configurations.py
@@ -28,6 +28,7 @@ from typing import Dict, List
 
 import pytest
 import yaml
+from aea.exceptions import AEAValidationError
 
 from autonomy.configurations.loader import load_service_config
 
@@ -104,6 +105,31 @@ class TestServiceConfig:
             ),
         ):
             load_service_config(self.t)
+
+    def test_env_vars(
+        self,
+    ) -> None:
+        """Test if env vars are properly loaded."""
+
+        env_placeholder = "${NUMBER_OF_AGENTS:int:1}"
+        dummy_service = get_dummy_service_config()
+        dummy_service[0]["number_of_agents"] = env_placeholder
+
+        self._write_service(dummy_service)
+
+        with pytest.raises(
+            AEAValidationError,
+            match=re.escape("'${NUMBER_OF_AGENTS:int:1}' is not of type 'integer'"),
+        ):
+            load_service_config(self.t)
+
+        dummy_service = get_dummy_service_config()
+        dummy_service[0]["number_of_agents"] = env_placeholder
+
+        self._write_service(dummy_service)
+
+        service = load_service_config(self.t, substitute_env_vars=True)
+        assert service.number_of_agents == 1
 
     @classmethod
     def teardown(


### PR DESCRIPTION
## Proposed changes

This PR adds support for substituting env vars when loading service configs

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [x] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

