### PR TITLE
Fix flaky `test_fetch_behaviour_non_indexed_block` test

### DIFF
--- a/tests/test_skills/test_apy_estimation_abci/test_behaviours.py
+++ b/tests/test_skills/test_apy_estimation_abci/test_behaviours.py
@@ -818,17 +818,15 @@ class TestFetchAndBatchBehaviours(APYEstimationFSMBehaviourBaseCase):
         else:
             res = {"errors": [{"message": "another error"}]}
 
-        response_kwargs["body"] = json.dumps(res).encode("utf-8")
-        behaviour.act_wrapper()
-        self.mock_http_request(request_kwargs, response_kwargs)
+        with caplog.at_level(
+            logging.WARNING,
+            logger="aea.test_agent_name.packages.valory.skills.apy_estimation_abci",
+        ):
+            response_kwargs["body"] = json.dumps(res).encode("utf-8")
+            behaviour.act_wrapper()
+            self.mock_http_request(request_kwargs, response_kwargs)
 
         if not is_non_indexed_res:
-            with caplog.at_level(
-                logging.WARNING,
-                logger="aea.test_agent_name.packages.valory.skills.apy_estimation_abci",
-            ):
-                behaviour.act_wrapper()
-
             assert (
                 "Attempted to handle an indexing error, but could not extract the latest indexed block!"
                 in caplog.text

--- a/tests/test_skills/test_apy_estimation_abci/test_behaviours.py
+++ b/tests/test_skills/test_apy_estimation_abci/test_behaviours.py
@@ -880,10 +880,7 @@ class TestFetchAndBatchBehaviours(APYEstimationFSMBehaviourBaseCase):
         block_from_timestamp_q: str,
         block_from_number_q: str,
         eth_price_usd_q: str,
-        uni_pairs_q: str,
         pairs_ids: Dict[str, List[str]],
-        pool_fields: Tuple[str, ...],
-        caplog: LogCaptureFixture,
     ) -> None:
         """Test `async_act` when we receive `None` responses in `_check_non_indexed_block`."""
         self.fast_forward_to_behaviour(


### PR DESCRIPTION
## Proposed changes

Fixes flaky `test_fetch_behaviour_non_indexed_block` test.

Example failing run: [Use local registry for registration tests main_workflow #4973](https://github.com/valory-xyz/open-autonomy/runs/8185034106?check_suite_focus=true)

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

n/a