### PR TITLE
Chore/staging ACN to local

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -219,6 +219,9 @@ jobs:
           docker pull valory/autonolas-registries:latest
           docker pull valory/contracts-amm:latest
           docker pull valory/safe-contract-net:latest
+          docker pull valory/acn-node:latest
+          docker pull tendermint/tendermint:v0.34.19
+          docker pull trufflesuite/ganache:beta
 
       - if: matrix.os == 'ubuntu-latest'
         name: Framework unit tests ubuntu-latest

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -42,7 +42,7 @@
     "agent/valory/hello_world/0.1.0": "bafybeicqhwxerp5codhdpiobfv3aaquig2qbci442yvvf65ziuenaad3wq",
     "agent/valory/oracle/0.1.0": "bafybeiarh3wkocultmi3i6athorlwxj2hrs2toife7lxcerhf6kakvyoea",
     "agent/valory/register_reset/0.1.0": "bafybeiaw2dc462bvy5ycrcdd22juhzrzf3zzi4u6ls5e2qa4ml4o3skxcm",
-    "agent/valory/registration_start_up/0.1.0": "bafybeieyqcv6bb37oyx3u6ix7m7oq5tkshzihemxlbsdbgtlclfv4ix3n4",
+    "agent/valory/registration_start_up/0.1.0": "bafybeicylq7okzw4lw3be4ixgqr6pkrnlfi63enawfwznqxconrxgrnjqm",
     "agent/valory/simple_abci/0.1.0": "bafybeidfv553nxcyqgg7s4kosxoseba5ru7ygm3dsy7fuierdstesmjraq",
     "agent/valory/test_abci/0.1.0": "bafybeiarewndibdcjtptohdxwiyieki2fy37ddtqsjgfor2h6h2flc5leq",
     "service/valory/apy_estimation/0.1.0": "bafybeidc6frvgv4b76klygjhi4mbknmd4khyrdkfuecslb3d3xusennep4",

--- a/packages/valory/agents/registration_start_up/aea-config.yaml
+++ b/packages/valory/agents/registration_start_up/aea-config.yaml
@@ -8,7 +8,7 @@ fingerprint:
   README.md: bafybeicqrks6wbtytebsnuvkojqy4e7x7puttrgseebbdwazjazrik4rzq
   __init__.py: bafybeiafjxnpd5dldlw2nu2xxdzvry2mlixrlooath5kbkideuvvfyei4u
   tests/__init__.py: bafybeifmfadp3anskpzai4l6dg6ikxvqauzhp2iuizpxvu7q4vvnnpijoi
-  tests/test_registration.py: bafybeih5252h6e4czdtpsukuvthbhittqkerjrepyjmgemwgmyxhdcjwlm
+  tests/test_registration.py: bafybeifjqvw3fzabl3fpqthnme3tcmstxrxiv4gqifdrszv76hvhygckpe
 fingerprint_ignore_patterns: []
 connections:
 - valory/abci:0.1.0:bafybeih34yj6l7akh6wfhgwaud3luvmwxkiakcqzv3zjiz5q7jfqtdnela

--- a/packages/valory/agents/registration_start_up/aea-config.yaml
+++ b/packages/valory/agents/registration_start_up/aea-config.yaml
@@ -8,7 +8,7 @@ fingerprint:
   README.md: bafybeicqrks6wbtytebsnuvkojqy4e7x7puttrgseebbdwazjazrik4rzq
   __init__.py: bafybeiafjxnpd5dldlw2nu2xxdzvry2mlixrlooath5kbkideuvvfyei4u
   tests/__init__.py: bafybeifmfadp3anskpzai4l6dg6ikxvqauzhp2iuizpxvu7q4vvnnpijoi
-  tests/test_registration.py: bafybeiap4jomjygf3vmfcl5kwt4uwriokquf3pejqigag6mwusbcgirg4m
+  tests/test_registration.py: bafybeih5252h6e4czdtpsukuvthbhittqkerjrepyjmgemwgmyxhdcjwlm
 fingerprint_ignore_patterns: []
 connections:
 - valory/abci:0.1.0:bafybeih34yj6l7akh6wfhgwaud3luvmwxkiakcqzv3zjiz5q7jfqtdnela

--- a/packages/valory/agents/registration_start_up/aea-config.yaml
+++ b/packages/valory/agents/registration_start_up/aea-config.yaml
@@ -8,7 +8,7 @@ fingerprint:
   README.md: bafybeicqrks6wbtytebsnuvkojqy4e7x7puttrgseebbdwazjazrik4rzq
   __init__.py: bafybeiafjxnpd5dldlw2nu2xxdzvry2mlixrlooath5kbkideuvvfyei4u
   tests/__init__.py: bafybeifmfadp3anskpzai4l6dg6ikxvqauzhp2iuizpxvu7q4vvnnpijoi
-  tests/test_registration.py: bafybeidu6jinlntxq76ye4qbneecimitjfjr5ayod7lg2jmd73vkhgadmm
+  tests/test_registration.py: bafybeiap4jomjygf3vmfcl5kwt4uwriokquf3pejqigag6mwusbcgirg4m
 fingerprint_ignore_patterns: []
 connections:
 - valory/abci:0.1.0:bafybeih34yj6l7akh6wfhgwaud3luvmwxkiakcqzv3zjiz5q7jfqtdnela
@@ -96,14 +96,14 @@ public_id: valory/p2p_libp2p_client:0.1.0
 type: connection
 config:
   nodes:
-  - uri: ${P2P_URI:str:acn.staging.autonolas.tech:9006}
-    public_key: ${P2P_PUBLIC_KEY:str:02e741c62d706e1dcf6986bf37fa74b98681bc32669623ac9ee6ff72488d4f59e8}
+  - uri: ${P2P_URI:str:localhost:11000}
+    public_key: ${P2P_PUBLIC_KEY:str:03c74dbfbe7bbc1b42429f78778017a3cd7eaf9d59d1634c9505a3f7c1a9350e71}
 cert_requests:
 - identifier: acn
   ledger_id: ethereum
   message_format: '{public_key}'
   not_after: '2023-01-01'
   not_before: '2022-01-01'
-  public_key: ${P2P_PUBLIC_KEY:str:02e741c62d706e1dcf6986bf37fa74b98681bc32669623ac9ee6ff72488d4f59e8}
-  save_path: .certs/acn_cosmos_9006.txt
+  public_key: ${P2P_PUBLIC_KEY:str:03c74dbfbe7bbc1b42429f78778017a3cd7eaf9d59d1634c9505a3f7c1a9350e71}
+  save_path: .certs/acn_cosmos_11000.txt
 is_abstract: false

--- a/packages/valory/agents/registration_start_up/tests/test_registration.py
+++ b/packages/valory/agents/registration_start_up/tests/test_registration.py
@@ -78,7 +78,7 @@ STRICT_CHECK_STRINGS = (
 )
 
 
-HAPPY_PATH = RoundChecks("registration_startup"),
+HAPPY_PATH = (RoundChecks("registration_startup"),)
 
 
 class RegistrationStartUpTestConfig(UseRegistries, UseACNNode, BaseTestEnd2End):

--- a/packages/valory/agents/registration_start_up/tests/test_registration.py
+++ b/packages/valory/agents/registration_start_up/tests/test_registration.py
@@ -31,6 +31,7 @@ from aea.configurations.data_types import PublicId
 from aea_test_autonomy.base_test_classes.agents import (
     BaseTestEnd2End,
     BaseTestEnd2EndExecution,
+    RoundChecks,
 )
 from aea_test_autonomy.fixture_helpers import (  # noqa: F401
     UseACNNode,
@@ -77,12 +78,16 @@ STRICT_CHECK_STRINGS = (
 )
 
 
+HAPPY_PATH = RoundChecks("registration_startup"),
+
+
 class RegistrationStartUpTestConfig(UseRegistries, UseACNNode, BaseTestEnd2End):
     """Base class for e2e tests using the ACN client connection"""
 
     skill_package = "valory/registration_abci:0.1.0"
     agent_package = "valory/registration_start_up:0.1.0"
     wait_to_finish = 60
+    happy_path = HAPPY_PATH
     strict_check_strings: Tuple[str, ...] = STRICT_CHECK_STRINGS
     __p2p_prefix = "vendor.valory.connections.p2p_libp2p_client"
     __args_prefix = f"vendor.valory.skills.{PublicId.from_str(skill_package).name}.models.params.args"

--- a/plugins/aea-test-autonomy/aea_test_autonomy/docker/acn_node.py
+++ b/plugins/aea-test-autonomy/aea_test_autonomy/docker/acn_node.py
@@ -68,7 +68,7 @@ class ACNNodeDockerImage(DockerImage):
     @property
     def tag(self) -> str:
         """Get the image tag."""
-        return "valory/acn-node:0.1.0"
+        return "valory/acn-node:latest"
 
     def _make_ports(self) -> Dict:
         """Make ports dictionary for Docker."""


### PR DESCRIPTION
## Proposed changes

changed staging ACN to local node. I only changed `agents/registration_start_up/aea-config.yaml`, not the other aea-config files. That is because these e2e tests do not use the ACN Docker image either. Meaning both that: 
- `p2p_libp2p_client.is_abstract: true` in `aea-config.yaml` and 
- `models.params.args.share_tm_config_on_startup: false` in all `skill.yaml` files.

relates to issue https://github.com/valory-xyz/open-autonomy/issues/1287

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
