### PR TITLE
feat: adds open-autonomy-user image

### DIFF
--- a/deployments/Dockerfiles/autonomy-user/Dockerfile
+++ b/deployments/Dockerfiles/autonomy-user/Dockerfile
@@ -1,0 +1,26 @@
+# Base image
+FROM python:3.10-slim-bullseye as base
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN apt-get update -y && apt-get install gcc -y && rm -rf /var/lib/apt/lists/*
+
+# Install library dependencies into our venv
+RUN python3 -m venv $VIRTUAL_ENV
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+# Customize base image with agent deps
+FROM python:3.10-slim-bullseye as agent_deps
+ARG AUTHOR=user
+
+ENV VIRTUAL_ENV=/opt/venv
+COPY --from=base $VIRTUAL_ENV $VIRTUAL_ENV
+
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Setup autonomy and prepare image
+RUN autonomy init --remote --ipfs --reset --author $AUTHOR
+
+ENTRYPOINT [ "/bin/bash"]

--- a/deployments/Dockerfiles/autonomy-user/requirements.txt
+++ b/deployments/Dockerfiles/autonomy-user/requirements.txt
@@ -1,0 +1,5 @@
+open-autonomy[all]==0.3.0
+open-aea[all]==1.19.0
+open-aea-cli-ipfs==1.19.0
+open-aea-ledger-ethereum==1.19.0
+protobuf==3.19.4

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -60,7 +60,7 @@ profiles:
           <<: *release_docker_args
           buildArgs: &oar-oracle
             <<: *aea_version
-            AEA_AGENT: "{{=AEA_AGENT_ORACLE}}"
+            AEA_AGENT: "{{.AEA_AGENT_ORACLE}}"
 
       - image: valory/oar-apy_estimation
         <<: *open_autonomy_runtime_context

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,5 +1,5 @@
 .aea_version: &aea_version
-  AEA_VERSION: "1.17.0"
+  AEA_VERSION: "1.19.0"
   AUTHOR: "valory"
 .docker_args: &docker_args
   dockerfile: Dockerfile
@@ -60,7 +60,7 @@ profiles:
           <<: *release_docker_args
           buildArgs: &oar-oracle
             <<: *aea_version
-            AEA_AGENT: "{{.AEA_AGENT_ORACLE}}"
+            AEA_AGENT: "{{=AEA_AGENT_ORACLE}}"
 
       - image: valory/oar-apy_estimation
         <<: *open_autonomy_runtime_context
@@ -69,6 +69,13 @@ profiles:
           buildArgs: &oar-apy_estimation
             <<: *aea_version
             AEA_AGENT: "{{.AEA_AGENT_APY_ESTIMATION}}"
+
+      - image: valory/open-autonomy-user
+        context: deployments/Dockerfiles/autonomy-user
+        docker:
+          <<: *release_docker_args
+          buildArgs: 
+            <<: *aea_version
 
   - name: release-latest
     build:
@@ -112,3 +119,10 @@ profiles:
           <<: *docker_args
           buildArgs:
             <<: *oar-apy_estimation
+
+      - image: valory/open-autonomy-user
+        context: deployments/Dockerfiles/autonomy-user
+        docker:
+          <<: *release_docker_args
+          buildArgs: 
+            <<: *aea_version


### PR DESCRIPTION
## Proposed changes

Adds `valory/open-autonomy-user` Docker image with latest `open-autonomy` framework installed, ready for use.

Image can be pulled with `docker pull valory/open-autonomy-user:latest` and used with `docker run -it valory/open-autonomy-user:latest`

## Fixes

#1338

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

-