### PR TITLE
Use subprocesses in `TestCheckSpecs` and `TestScaffoldFSMAutonomyTests`

### DIFF
--- a/tests/test_autonomy/test_cli/test_analyse/test_abci/test_specs.py
+++ b/tests/test_autonomy/test_cli/test_analyse/test_abci/test_specs.py
@@ -161,30 +161,30 @@ class TestCheckSpecs(BaseCliTest):
         self,
     ) -> None:
         """Test with one class."""
-        result = self.run_cli(
+        return_code, stdout, stderr = self.run_cli_subprocess(
             ("--app-class", self.cls_name, "--infile", str(self.specification_path))
         )
 
-        assert result.exit_code == 0
-        assert result.output == f"Checking : {self.cls_name}\nCheck successful\n"
+        assert return_code == 0
+        assert stdout == f"Checking : {self.cls_name}\nCheck successful\n"
 
     def test_one_fail(
         self,
     ) -> None:
         """Test with one class failing."""
         self._corrupt_spec_file()
-        result = self.run_cli(
+        return_code, stdout, stderr = self.run_cli_subprocess(
             ("--app-class", self.cls_name, "--infile", str(self.specification_path))
         )
 
-        assert result.exit_code == 1
-        assert result.output == f"Checking : {self.cls_name}\nCheck failed.\n"
+        assert return_code == 1
+        assert stdout == f"Checking : {self.cls_name}\nCheck failed.\n"
 
     def test_check_all(
         self,
     ) -> None:
         """Test --check-all flag."""
-        result = self.run_cli(
+        return_code, stdout, stderr = self.run_cli_subprocess(
             (
                 "--check-all",
                 "--packages-dir",
@@ -192,15 +192,15 @@ class TestCheckSpecs(BaseCliTest):
             )
         )
 
-        assert result.exit_code == 0
-        assert "Check successful." in result.output
+        assert return_code == 0
+        assert "Check successful." in stdout
 
     def test_check_all_fail(
         self,
     ) -> None:
         """Test --check-all flag."""
         self._corrupt_spec_file()
-        result = self.run_cli(
+        return_code, stdout, stderr = self.run_cli_subprocess(
             (
                 "--check-all",
                 "--packages-dir",
@@ -208,10 +208,8 @@ class TestCheckSpecs(BaseCliTest):
             )
         )
 
-        assert result.exit_code == 1
-        assert (
-            "Specifications did not match for following definitions." in result.output
-        )
+        assert return_code == 1
+        assert "Specifications did not match for following definitions." in stdout
 
     def test_failures(
         self,
@@ -228,6 +226,12 @@ class TestCheckSpecs(BaseCliTest):
         assert (
             "Please provide path to specification file." in result.output
         ), result.output
+
+    def teardown(
+        self,
+    ) -> None:
+        """Tear down the test."""
+        super().teardown()
 
 
 class TestDFA:


### PR DESCRIPTION
## Proposed changes

This PR makes `TestCheckSpecs` and `TestScaffoldFSMAutonomyTests` to use subprocess for each test to better isolate the Python environment of the CLI command being executed.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [X] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

n/a