### PR TITLE
fix: remove skipped doc links

### DIFF
--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -113,12 +113,12 @@ def check_file(
                 verify=False,
             ).status_code
             if status_code not in [200, 403]:
-                broken_links.append((md_file, url, status_code))
+                broken_links.append({"url": url, "status_code": status_code})
         except (
             requests.exceptions.RetryError,
             requests.exceptions.ConnectionError,
         ) as e:
-            broken_links.append((md_file, url, e))
+            broken_links.append({"url": url, "status_code": e})
 
     return {
         "file": str(md_file),
@@ -131,7 +131,7 @@ def main() -> None:  # pylint: disable=too-many-locals
     """Check for broken or HTTP links"""
     all_md_files = [str(p.relative_to(".")) for p in Path("docs").rglob("*.md")]
 
-    broken_links: Dict[str, List[str]] = {}
+    broken_links: Dict[str, Dict] = {}
     http_links: Dict[str, List[str]] = {}
 
     # Configure request retries
@@ -169,8 +169,8 @@ def main() -> None:  # pylint: disable=too-many-locals
         if broken_links:
             broken_links_str = "\n".join(
                 [
-                    f"{file_name}: {[(url[1], url[2]) for url in urls]}"
-                    for file_name, urls in broken_links.items()
+                    f"{file_name}: {[entry['url'] + ', status: ' + str(entry['status_code']) for entry in error_data]}"
+                    for file_name, error_data in broken_links.items()
                 ]
             )
             print(f"Found broken url in the docs:\n{broken_links_str}")


### PR DESCRIPTION
## Proposed changes

Remove skipped link checks for CI testing purposes.
Investigating [this](https://github.com/valory-xyz/open-autonomy/actions/runs/3288400682/jobs/5418997739) failure that was passing locally:
```
Awaiting for results...
Found broken url in the docs:
docs/get_started/why_do_we_need_agent_services.md: ['https://encyclopedia.pub/entry/2959']
ERROR: InvocationError for command /home/runner/work/open-autonomy/open-autonomy/scripts/check_doc_links.py (exited with code 1)
```

Redirects should not be a problem as the [requests library automatically follows](https://requests.readthedocs.io/en/latest/user/quickstart/#redirection-and-history) those. Could it be that we were getting a TooManyRedirects and being rate-limited? I've added the http status code to the logging so it is easier to debug and fix next time.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes
