### PR TITLE
fix: test_get_app_hash

### DIFF
--- a/tests/test_deployments/test_app.py
+++ b/tests/test_deployments/test_app.py
@@ -199,13 +199,13 @@ class TestTendermintServerApp(BaseTendermintServerTest):
     @wait_for_node_to_run
     def test_get_app_hash(self) -> None:
         """Test get app hash"""
-        time.sleep(5)  # requires some extra time!
         with self.app.test_client() as client:
-            response = client.get("/app_hash")
-            data = response.get_json()
-            assert response.status_code == 200
-            assert "error" not in data
-            assert "app_hash" in data
+            wait_for_condition(
+                lambda: "app_hash" in client.get("/app_hash").get_json(),
+                timeout=10,
+                period=1,
+                error_msg="Could not retrieve `app_hash` from Tendermint server",
+            )
 
 
 class TestTendermintGentleResetServer(BaseTendermintServerTest):


### PR DESCRIPTION
## Proposed changes

test fails repeatedly 
- here https://github.com/valory-xyz/open-autonomy/pull/1506#issuecomment-1301815361
    ```
        @wait_for_node_to_run
        def test_get_app_hash(self) -> None:
            """Test get app hash"""
            time.sleep(5)  # requires some extra time!
            with self.app.test_client() as client:
                response = client.get("/app_hash")
                data = response.get_json()
                assert response.status_code == 200
    >           assert "error" not in data
    E           assert 'error' not in {'error': "Could not get the app hash: HTTPConnectionPool(host='127.0.0.1', port=26657): Max retries exceeded with url: /block (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x000001B023D38190>: Failed to establish a new connection: [WinError 10061] No connection could be made because the target machine actively refused it'))"}
    ```
- and here: https://github.com/valory-xyz/open-autonomy/pull/1499#issuecomment-1300120240
    ```
    ================================== FAILURES ===================================
    __________________ TestTendermintServerApp.test_get_app_hash __________________
    
    self = <tests.test_deployments.test_app.TestTendermintServerApp object at 0x0000019D2FDB8C10>
    
        @wait_for_node_to_run
        def test_get_app_hash(self) -> None:
            """Test get app hash"""
            time.sleep(5)  # requires some extra time!
            with self.app.test_client() as client:
                response = client.get("/app_hash")
                data = response.get_json()
                assert response.status_code == 200
    >           assert "error" not in data
    E           assert 'error' not in {'error': "Could not get the app hash: 'NoneType' object is not subscriptable"}
    ```

Particularly the first failure is remarkable, since this test, also part of `TestTendermintServerApp`,  passed:
https://github.com/valory-xyz/open-autonomy/blob/acaeb2aee6a038744014a5ead425a712afb4e36a/tests/test_deployments/test_app.py#L185-L190

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
