### PR TITLE
fix: copy spec file when scaffolding fsm skill

### DIFF
--- a/autonomy/cli/scaffold_fsm.py
+++ b/autonomy/cli/scaffold_fsm.py
@@ -29,6 +29,7 @@ import os
 import re
 import shutil
 from abc import ABC, abstractmethod
+from io import StringIO
 from pathlib import Path
 from textwrap import dedent, indent
 from typing import Dict, List, Type
@@ -635,7 +636,7 @@ class ScaffoldABCISkill:
         self.spec_path = spec_path
 
         # process FSM specification
-        self.dfa = self._parse_spec(self.spec_path)
+        self.dfa = DFA.load(StringIO(spec_path.read_text()), input_format="yaml")
 
     @property
     def skill_dir(self) -> Path:
@@ -646,12 +647,6 @@ class ScaffoldABCISkill:
     def skill_test_dir(self) -> Path:
         """Get the directory to the skill tests."""
         return self.skill_dir / "tests"
-
-    @classmethod
-    def _parse_spec(cls, spec_path: Path) -> DFA:
-        """Parse the FSM specification."""
-        with spec_path.open(encoding="utf-8") as fp:
-            return DFA.load(fp, input_format="yaml")
 
     def do_scaffolding(self) -> None:
         """Do the scaffolding."""

--- a/docs/api/cli/scaffold_fsm.md
+++ b/docs/api/cli/scaffold_fsm.md
@@ -409,7 +409,7 @@ Utility class that implements the scaffolding of the ABCI skill.
 #### `__`init`__`
 
 ```python
-def __init__(ctx: Context, skill_name: str, dfa: DFA) -> None
+def __init__(ctx: Context, skill_name: str, spec_path: Path) -> None
 ```
 
 Initialize the utility class.

--- a/tests/test_autonomy/test_cli/test_scaffold_fsm.py
+++ b/tests/test_autonomy/test_cli/test_scaffold_fsm.py
@@ -128,6 +128,11 @@ class TestScaffoldFSM(BaseScaffoldFSMTest):
             module_type = importlib.util.module_from_spec(module_spec)
             module_spec.loader.exec_module(module_type)  # type: ignore
 
+        # check spec file is in skill directory
+        assert (
+            self.t / self.agent_name / "skills" / skill_name / fsm_spec_file.name
+        ).exists(), "spec file not copied in scaffolded skill"
+
 
 class TestScaffoldFSMAutonomyTests(BaseScaffoldFSMTest):
     """Test `scaffold fsm` subcommand."""


### PR DESCRIPTION
## Proposed changes

This PR makes the scaffold fsm command to copy the specification file in the skill directory when scaffolding the skill.

## Fixes

Fix #1437

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [X] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

n/a