### PR TITLE
Fix: restart agents

### DIFF
--- a/plugins/aea-test-autonomy/aea_test_autonomy/base_test_classes/agents.py
+++ b/plugins/aea-test-autonomy/aea_test_autonomy/base_test_classes/agents.py
@@ -447,7 +447,7 @@ class BaseTestEnd2EndExecution(BaseTestEnd2End):
         # don't pop before termination, seems to lead to failure!
         for i in range(self.n_terminal):
             agent_name = self._get_agent_name(i)
-            self.terminate_agents(self.processes[i], timeout=0)
+            self.processes[i].terminate()
             self.processes.pop(i)
             logging.info(f"Terminated {agent_name}")
 


### PR DESCRIPTION
## Proposed changes

New release of open-aea we raise a TimeoutError when the subprocess doesn't terminate before a timeout. We used timeout=0 in our `BaseTestEnd2EndExecution._restart_agents` method. Now agent termination is to be directly invoked in e2e test setup, such that it most closely resembles the original implementation before the agent termination process was updated (scenario most likely to be seen in the wild).

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
