### PR TITLE
[0.4.1] Fix: cli runner stream capture via capfd

### DIFF
--- a/tests/test_autonomy/test_cli/base.py
+++ b/tests/test_autonomy/test_cli/base.py
@@ -27,6 +27,7 @@ import tempfile
 from contextlib import suppress
 from pathlib import Path
 from typing import Optional, Sequence, Tuple
+
 import pytest
 from _pytest.capture import CaptureFixture  # type: ignore
 from aea.test_tools.click_testing import CliRunner

--- a/tests/test_autonomy/test_cli/base.py
+++ b/tests/test_autonomy/test_cli/base.py
@@ -60,11 +60,6 @@ class BaseCliTest:
         """Setup test."""
         self.t = Path(tempfile.mkdtemp())
 
-    @property
-    def capfd(self) -> CaptureFixture:
-        """CliRunner capfd fixture"""
-        return self.cli_runner.capfd
-
     def run_cli(self, commands: Optional[Tuple[str, ...]] = None) -> Result:
         """Run CLI."""
         if commands is None:

--- a/tests/test_autonomy/test_cli/base.py
+++ b/tests/test_autonomy/test_cli/base.py
@@ -27,7 +27,8 @@ import tempfile
 from contextlib import suppress
 from pathlib import Path
 from typing import Optional, Sequence, Tuple
-
+import pytest
+from _pytest.capture import CaptureFixture  # type: ignore
 from aea.test_tools.click_testing import CliRunner
 from click.testing import Result
 
@@ -36,6 +37,11 @@ from autonomy.cli import cli
 
 class BaseCliTest:
     """Test `autonomy analyse abci` command."""
+
+    @pytest.fixture(autouse=True)
+    def set_capfd_on_cli_runner(self, capfd: CaptureFixture) -> None:
+        """Set pytest capfd on CLI runner"""
+        self.cli_runner.capfd = capfd
 
     t: Path
     cwd: Path
@@ -53,6 +59,11 @@ class BaseCliTest:
     ) -> None:
         """Setup test."""
         self.t = Path(tempfile.mkdtemp())
+
+    @property
+    def capfd(self) -> CaptureFixture:
+        """CliRunner capfd fixture"""
+        return self.cli_runner.capfd
 
     def run_cli(self, commands: Optional[Tuple[str, ...]] = None) -> Result:
         """Run CLI."""

--- a/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
@@ -104,7 +104,6 @@ class TestFromToken(BaseCliTest):
 
     def test_from_token(
         self,
-        capsys: Any,
     ) -> None:
         """Run test."""
 
@@ -137,7 +136,7 @@ class TestFromToken(BaseCliTest):
                 )
             )
 
-            out, err = capsys.readouterr()
+            out, err = self.capfd.readouterr()
 
             assert result.exit_code == 0, out
             assert "Service name: valory/oracle_hardhat" in out, err

--- a/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
@@ -136,12 +136,10 @@ class TestFromToken(BaseCliTest):
                 )
             )
 
-            out, err = self.capfd.readouterr()
-
-            assert result.exit_code == 0, out
-            assert "Service name: valory/oracle_hardhat" in out, err
-            assert "Building required images" in out, err
-            assert "Service build successful" in out, err
+            assert result.exit_code == 0, result.stdout
+            assert "Service name: valory/oracle_hardhat" in result.stdout
+            assert "Building required images" in result.stdout
+            assert "Service build successful" in result.stdout
 
     def test_fail_on_chain_resolve_connection_error(self) -> None:
         """Run test."""

--- a/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
@@ -22,7 +22,6 @@
 import json
 import os
 from pathlib import Path
-from typing import Any
 from unittest import mock
 
 import pytest

--- a/tests/test_autonomy/test_cli/test_fetch.py
+++ b/tests/test_autonomy/test_cli/test_fetch.py
@@ -91,7 +91,7 @@ class TestFetchCommand(BaseCliTest):
 
         shutil.rmtree(service)
 
-    def test_publish_and_fetch_service_ipfs(self, capsys: Any) -> None:
+    def test_publish_and_fetch_service_ipfs(self) -> None:
         """Test fetch service."""
         expected_hash = "bafybeic7k4hlrozzc6gfoaygnjr22tg6ukua3rdxt5fmkaplysrw3txvii"
 
@@ -114,7 +114,7 @@ class TestFetchCommand(BaseCliTest):
             service_dir
         ):
             result = self.cli_runner.invoke(cli, ["publish", "--remote"])
-            output = capsys.readouterr()
+            output = self.capfd.readouterr()
 
             assert result.exit_code == 0, output
             assert expected_hash in output.out, output.err

--- a/tests/test_autonomy/test_cli/test_fetch.py
+++ b/tests/test_autonomy/test_cli/test_fetch.py
@@ -114,10 +114,9 @@ class TestFetchCommand(BaseCliTest):
             service_dir
         ):
             result = self.cli_runner.invoke(cli, ["publish", "--remote"])
-            output = self.capfd.readouterr()
 
-            assert result.exit_code == 0, output
-            assert expected_hash in output.out, output.err
+            assert result.exit_code == 0, result.output
+            assert expected_hash in result.output
 
         with mock.patch(
             "autonomy.cli.helpers.registry.get_default_remote_registry",

--- a/tests/test_autonomy/test_cli/test_fetch.py
+++ b/tests/test_autonomy/test_cli/test_fetch.py
@@ -23,7 +23,6 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Any
 from unittest import mock
 
 from aea.configurations.loader import ConfigLoader


### PR DESCRIPTION
## Proposed changes

Capturing of `sys.stdout` and `sys.stderr` via autouse fixture setting `capfd` on the `CliRunner` in `BaseCliTest`. Optional use of this patch was recently added in open-aea release v1.25.0 to reduce flakiness in tests.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
