### PR TITLE
Fix agent instance validation

### DIFF
--- a/autonomy/deploy/base.py
+++ b/autonomy/deploy/base.py
@@ -186,6 +186,17 @@ class ServiceBuilder:
                 f"Key file contains keys which are not registered as instances; invalid keys={key_not_in_instances}"
             )
 
+        instances_not_in_keys = instances.difference(addresses)
+        if instances_not_in_keys:
+            logging.warning(
+                f"Key file does not contain key pair for following instances {instances_not_in_keys}"
+            )
+
+        keys_found_with_instances = instances.intersection(addresses)
+        logging.info(
+            f"Found following keys with registered instances {keys_found_with_instances}"
+        )
+
     def read_keys(self, keys_file: Path) -> None:
         """Read in keys from a file on disk."""
 

--- a/autonomy/deploy/base.py
+++ b/autonomy/deploy/base.py
@@ -186,12 +186,6 @@ class ServiceBuilder:
                 f"Key file contains keys which are not registered as instances; invalid keys={key_not_in_instances}"
             )
 
-        instances_not_in_keys = instances.difference(addresses)
-        if instances_not_in_keys:
-            raise NotValidKeysFile(
-                f"Key file does not contain key pair for following instances {instances_not_in_keys}"
-            )
-
     def read_keys(self, keys_file: Path) -> None:
         """Read in keys from a file on disk."""
 

--- a/tests/test_autonomy/test_deploy/test_service_specification.py
+++ b/tests/test_autonomy/test_deploy/test_service_specification.py
@@ -182,15 +182,6 @@ class TestServiceBuilder:
         ):
             spec.agent_instances = []
 
-        with pytest.raises(
-            NotValidKeysFile,
-            match="Key file does not contain key pair for following instances",
-        ):
-            spec.agent_instances = [
-                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                "0xDummyaddress",
-            ]
-
     def test_try_update_multisig_address_failure(self, caplog: Any) -> None:
         """Test `try_update_multisig_address` method."""
         multisig_address = "0xMULTISIGADDRESS"
@@ -264,16 +255,6 @@ class TestServiceBuilder:
         ):
             ServiceBuilder.verify_agent_instances([{"address": "0xaddress0"}], [])
 
-        with pytest.raises(
-            NotValidKeysFile,
-            match=re.escape(
-                "Key file does not contain key pair for following instances {'0xaddress1'}"
-            ),
-        ):
-            ServiceBuilder.verify_agent_instances(
-                [{"address": "0xaddress0"}], ["0xaddress0", "0xaddress1"]
-            )
-
     def test_set_number_of_agents(
         self,
     ) -> None:
@@ -337,21 +318,6 @@ class TestServiceBuilder:
         ):
             ServiceBuilder.from_dir(
                 self.service_path, self.keys_path, agent_instances=[]
-            )
-
-        with pytest.raises(
-            NotValidKeysFile,
-            match=re.escape(
-                "Key file does not contain key pair for following instances {'0xDummyAddress'}"
-            ),
-        ):
-            ServiceBuilder.from_dir(
-                self.service_path,
-                self.keys_path,
-                agent_instances=[
-                    "0xDummyAddress",
-                    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-                ],
             )
 
     @classmethod

--- a/tests/test_autonomy/test_deploy/test_service_specification.py
+++ b/tests/test_autonomy/test_deploy/test_service_specification.py
@@ -167,6 +167,7 @@ class TestServiceBuilder:
 
     def test_agent_instance_setter(
         self,
+        caplog: Any,
     ) -> None:
         """Test agent instance setter."""
 
@@ -181,6 +182,25 @@ class TestServiceBuilder:
             match="Key file contains keys which are not registered as instances",
         ):
             spec.agent_instances = []
+
+        with caplog.at_level(logging.WARNING):
+            spec.agent_instances = [
+                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+                "0xDummyaddress",
+            ]
+            assert (
+                "Key file does not contain key pair for following instances {'0xDummyaddress'}"
+                in caplog.text
+            )
+
+        with caplog.at_level(logging.INFO):
+            spec.agent_instances = [
+                "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            ]
+            assert (
+                "Found following keys with registered instances {'0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'}"
+                in caplog.text
+            )
 
     def test_try_update_multisig_address_failure(self, caplog: Any) -> None:
         """Test `try_update_multisig_address` method."""
@@ -244,6 +264,7 @@ class TestServiceBuilder:
 
     def test_verify_agent_instances(
         self,
+        caplog: Any,
     ) -> None:
         """Test `verify_agent_instances` method."""
 
@@ -254,6 +275,24 @@ class TestServiceBuilder:
             ),
         ):
             ServiceBuilder.verify_agent_instances([{"address": "0xaddress0"}], [])
+
+        with caplog.at_level(logging.WARNING):
+            ServiceBuilder.verify_agent_instances(
+                [{"address": "0xaddress0"}], ["0xaddress0", "0xaddress1"]
+            )
+            assert (
+                "Key file does not contain key pair for following instances {'0xaddress1'}"
+                in caplog.text
+            )
+
+        with caplog.at_level(logging.INFO):
+            ServiceBuilder.verify_agent_instances(
+                [{"address": "0xaddress0"}], ["0xaddress0"]
+            )
+            assert (
+                "Found following keys with registered instances {'0xaddress0'}"
+                in caplog.text
+            )
 
     def test_set_number_of_agents(
         self,


### PR DESCRIPTION
## Proposed changes

This PR fixes the agent instance validation. 

Before this we used to raise when the key file had missing addresses from the agent instances list, which is not really a good idea because the key file might only contain one key for an operator and the agent instances might contain n amount of addresses.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
