### PR TITLE
patch: log agent termination on timeout

### DIFF
--- a/plugins/aea-test-autonomy/aea_test_autonomy/base_test_classes/agents.py
+++ b/plugins/aea-test-autonomy/aea_test_autonomy/base_test_classes/agents.py
@@ -422,7 +422,12 @@ class BaseTestEnd2EndExecution(BaseTestEnd2End):
             self._restart_agents()
 
         self.check_aea_messages()
-        self.terminate_agents(timeout=TERMINATION_TIMEOUT)
+        try:
+            self.terminate_agents(timeout=TERMINATION_TIMEOUT)
+        except TimeoutError:
+            # This is rare, though it has occurred that even after a kill signal
+            # with a 30s timeout the subprocess did not terminate.
+            logging.error(f"Failed to terminate agents after {TERMINATION_TIMEOUT}s")
 
     def _restart_agents(self) -> None:
         """Stops and restarts agents after stop string is found."""


### PR DESCRIPTION
## Proposed changes

We have once so far witnessed an agent not terminating 30 seconds after sending a kill signal - [this CI run](https://github.com/valory-xyz/open-autonomy/actions/runs/3619754375/jobs/6101371159). 
Opened [issue #474](https://github.com/valory-xyz/open-aea/issues/474) on open-aea.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
