### PR TITLE
[WIP]: Insert only synchronized data in the db

### DIFF
--- a/packages/valory/skills/abstract_round_abci/base.py
+++ b/packages/valory/skills/abstract_round_abci/base.py
@@ -637,7 +637,7 @@ class AbciAppDB:
     def reset_index(self) -> int:
         """Get the current reset index."""
         # should return the last key or 0 if we have no data
-        return list(self._data)[-1] if self._data else 0
+        return list(self._data)[-1] if self._data else RESET_COUNT_START
 
     @property
     def round_count(self) -> int:

--- a/packages/valory/skills/abstract_round_abci/base.py
+++ b/packages/valory/skills/abstract_round_abci/base.py
@@ -851,6 +851,16 @@ class BaseSynchronizedData:
         :param synced_setup_data: the synchronized setup data to initialize the database with.
         """
         self.db.initialize(synced_setup_data)
+        missing_keys = []
+        for mandatory_key in self.default_db_keys:
+            # we do not check if the attribute exists since this is done during the chaining
+            if not getattr(self, mandatory_key):
+                missing_keys.append(mandatory_key)
+
+        enforce(
+            not missing_keys,
+            f"There are missing setup data {missing_keys} after initialization!",
+        )
 
     def update(
         self,


### PR DESCRIPTION
## Proposed changes

Refactors the db and the synchronized data in such a way that the `self._data` only gets initialized after an initialization method is called by the `RegistrationStartupRound`. The initialization inserts the setup data after they have been synchronized among the agents and can only be called once, otherwise raises. Moreover, if the initialization has not been completed, other CRUD operations cannot be performed.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

n/a