### PR TITLE
Make the usage of the tendermint testnet optional

### DIFF
--- a/autonomy/cli/deploy.py
+++ b/autonomy/cli/deploy.py
@@ -139,10 +139,12 @@ def deploy_group(
     help="Include an ACN node in the deployment setup.",
 )
 @click.option(
-    "--use-testnet",
+    "-ltm",
+    "--local-tm-setup",
+    "use_tm_testnet_setup",
     is_flag=True,
     default=False,
-    help="Use tendermint testnet setup.",
+    help="Use local tendermint chain setup.",
 )
 @click.option("--image-version", type=str, help="Define runtime image version.")
 @registry_flag()
@@ -166,7 +168,7 @@ def build_deployment_command(  # pylint: disable=too-many-arguments, too-many-lo
     image_version: Optional[str] = None,
     use_hardhat: bool = False,
     use_acn: bool = False,
-    use_testnet: bool = False,
+    use_tm_testnet_setup: bool = False,
 ) -> None:
     """Build deployment setup for n agents."""
 
@@ -214,7 +216,7 @@ def build_deployment_command(  # pylint: disable=too-many-arguments, too-many-lo
             image_version=image_version,
             use_hardhat=use_hardhat,
             use_acn=use_acn,
-            use_testnet=use_testnet,
+            use_tm_testnet_setup=use_tm_testnet_setup,
         )
     except (NotValidKeysFile, FileNotFoundError, FileExistsError) as e:
         shutil.rmtree(build_dir)

--- a/autonomy/cli/deploy.py
+++ b/autonomy/cli/deploy.py
@@ -138,6 +138,12 @@ def deploy_group(
     default=False,
     help="Include an ACN node in the deployment setup.",
 )
+@click.option(
+    "--use-testnet",
+    is_flag=True,
+    default=False,
+    help="Use tendermint testnet setup.",
+)
 @click.option("--image-version", type=str, help="Define runtime image version.")
 @registry_flag()
 @password_option(confirmation_prompt=True)
@@ -160,6 +166,7 @@ def build_deployment_command(  # pylint: disable=too-many-arguments, too-many-lo
     image_version: Optional[str] = None,
     use_hardhat: bool = False,
     use_acn: bool = False,
+    use_testnet: bool = False,
 ) -> None:
     """Build deployment setup for n agents."""
 
@@ -207,6 +214,7 @@ def build_deployment_command(  # pylint: disable=too-many-arguments, too-many-lo
             image_version=image_version,
             use_hardhat=use_hardhat,
             use_acn=use_acn,
+            use_testnet=use_testnet,
         )
     except (NotValidKeysFile, FileNotFoundError, FileExistsError) as e:
         shutil.rmtree(build_dir)

--- a/autonomy/cli/helpers/deployment.py
+++ b/autonomy/cli/helpers/deployment.py
@@ -139,7 +139,7 @@ def build_deployment(  # pylint: disable=too-many-arguments, too-many-locals
     image_version: Optional[str] = None,
     use_hardhat: bool = False,
     use_acn: bool = False,
-    use_testnet: bool = False,
+    use_tm_testnet_setup: bool = False,
 ) -> None:
     """Build deployment."""
     if build_dir.is_dir():  # pragma: no cover
@@ -174,7 +174,7 @@ def build_deployment(  # pylint: disable=too-many-arguments, too-many-locals
         image_version=image_version,
         use_hardhat=use_hardhat,
         use_acn=use_acn,
-        use_testnet=use_testnet,
+        use_tm_testnet_setup=use_tm_testnet_setup,
     )
     click.echo(report)
 

--- a/autonomy/cli/helpers/deployment.py
+++ b/autonomy/cli/helpers/deployment.py
@@ -139,6 +139,7 @@ def build_deployment(  # pylint: disable=too-many-arguments, too-many-locals
     image_version: Optional[str] = None,
     use_hardhat: bool = False,
     use_acn: bool = False,
+    use_testnet: bool = False,
 ) -> None:
     """Build deployment."""
     if build_dir.is_dir():  # pragma: no cover
@@ -173,6 +174,7 @@ def build_deployment(  # pylint: disable=too-many-arguments, too-many-locals
         image_version=image_version,
         use_hardhat=use_hardhat,
         use_acn=use_acn,
+        use_testnet=use_testnet,
     )
     click.echo(report)
 

--- a/autonomy/deploy/base.py
+++ b/autonomy/deploy/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021-2022 Valory AG
+#   Copyright 2021-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/autonomy/deploy/base.py
+++ b/autonomy/deploy/base.py
@@ -381,7 +381,7 @@ class BaseDeploymentGenerator(abc.ABC):
     output: str
     tendermint_job_config: Optional[str]
     dev_mode: bool
-    use_testnet: bool
+    use_tm_testnet_setup: bool
 
     packages_dir: Path
     open_aea_dir: Path
@@ -391,7 +391,7 @@ class BaseDeploymentGenerator(abc.ABC):
         self,
         service_builder: ServiceBuilder,
         build_dir: Path,
-        use_testnet: bool = False,
+        use_tm_testnet_setup: bool = False,
         dev_mode: bool = False,
         packages_dir: Optional[Path] = None,
         open_aea_dir: Optional[Path] = None,
@@ -401,7 +401,7 @@ class BaseDeploymentGenerator(abc.ABC):
 
         self.service_builder = service_builder
         self.build_dir = build_dir
-        self.use_testnet = use_testnet
+        self.use_tm_testnet_setup = use_tm_testnet_setup
         self.dev_mode = dev_mode
         self.packages_dir = packages_dir or Path.cwd().absolute() / "packages"
         self.open_aea_dir = open_aea_dir or Path.home().absolute() / "open-aea"

--- a/autonomy/deploy/base.py
+++ b/autonomy/deploy/base.py
@@ -381,6 +381,7 @@ class BaseDeploymentGenerator(abc.ABC):
     output: str
     tendermint_job_config: Optional[str]
     dev_mode: bool
+    use_testnet: bool
 
     packages_dir: Path
     open_aea_dir: Path
@@ -390,6 +391,7 @@ class BaseDeploymentGenerator(abc.ABC):
         self,
         service_builder: ServiceBuilder,
         build_dir: Path,
+        use_testnet: bool = False,
         dev_mode: bool = False,
         packages_dir: Optional[Path] = None,
         open_aea_dir: Optional[Path] = None,
@@ -399,6 +401,7 @@ class BaseDeploymentGenerator(abc.ABC):
 
         self.service_builder = service_builder
         self.build_dir = build_dir
+        self.use_testnet = use_testnet
         self.dev_mode = dev_mode
         self.packages_dir = packages_dir or Path.cwd().absolute() / "packages"
         self.open_aea_dir = open_aea_dir or Path.home().absolute() / "open-aea"

--- a/autonomy/deploy/build.py
+++ b/autonomy/deploy/build.py
@@ -50,6 +50,7 @@ def generate_deployment(  # pylint: disable=too-many-arguments, too-many-locals
     image_version: Optional[str] = None,
     use_hardhat: bool = False,
     use_acn: bool = False,
+    use_testnet: bool = False,
 ) -> str:
     """Generate the deployment for the service."""
 
@@ -75,6 +76,7 @@ def generate_deployment(  # pylint: disable=too-many-arguments, too-many-locals
         packages_dir=packages_dir,
         open_aea_dir=open_aea_dir,
         open_autonomy_dir=open_autonomy_dir,
+        use_testnet=use_testnet,
     )
 
     (

--- a/autonomy/deploy/build.py
+++ b/autonomy/deploy/build.py
@@ -50,7 +50,7 @@ def generate_deployment(  # pylint: disable=too-many-arguments, too-many-locals
     image_version: Optional[str] = None,
     use_hardhat: bool = False,
     use_acn: bool = False,
-    use_testnet: bool = False,
+    use_tm_testnet_setup: bool = False,
 ) -> str:
     """Generate the deployment for the service."""
 
@@ -76,7 +76,7 @@ def generate_deployment(  # pylint: disable=too-many-arguments, too-many-locals
         packages_dir=packages_dir,
         open_aea_dir=open_aea_dir,
         open_autonomy_dir=open_autonomy_dir,
-        use_testnet=use_testnet,
+        use_tm_testnet_setup=use_tm_testnet_setup,
     )
 
     (

--- a/autonomy/deploy/generators/docker_compose/base.py
+++ b/autonomy/deploy/generators/docker_compose/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021-2022 Valory AG
+#   Copyright 2021-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/autonomy/deploy/generators/docker_compose/base.py
+++ b/autonomy/deploy/generators/docker_compose/base.py
@@ -121,7 +121,7 @@ class DockerComposeGenerator(BaseDeploymentGenerator):
     def generate_config_tendermint(self) -> "DockerComposeGenerator":
         """Generate the command to configure tendermint testnet."""
 
-        if not self.use_testnet:
+        if not self.use_tm_testnet_setup:
             return self
 
         hosts = (

--- a/autonomy/deploy/generators/docker_compose/base.py
+++ b/autonomy/deploy/generators/docker_compose/base.py
@@ -121,6 +121,9 @@ class DockerComposeGenerator(BaseDeploymentGenerator):
     def generate_config_tendermint(self) -> "DockerComposeGenerator":
         """Generate the command to configure tendermint testnet."""
 
+        if not self.use_testnet:
+            return self
+
         hosts = (
             " \\\n".join(
                 [

--- a/autonomy/deploy/generators/kubernetes/base.py
+++ b/autonomy/deploy/generators/kubernetes/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021-2022 Valory AG
+#   Copyright 2021-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/autonomy/deploy/generators/kubernetes/base.py
+++ b/autonomy/deploy/generators/kubernetes/base.py
@@ -60,15 +60,17 @@ class KubernetesGenerator(BaseDeploymentGenerator):
         packages_dir: Optional[Path] = None,
         open_aea_dir: Optional[Path] = None,
         open_autonomy_dir: Optional[Path] = None,
+        use_testnet: bool = False,
     ) -> None:
         """Initialise the deployment generator."""
         super().__init__(
-            service_builder,
-            build_dir,
-            dev_mode,
-            packages_dir,
-            open_aea_dir,
-            open_autonomy_dir,
+            service_builder=service_builder,
+            build_dir=build_dir,
+            use_testnet=use_testnet,
+            dev_mode=dev_mode,
+            packages_dir=packages_dir,
+            open_aea_dir=open_aea_dir,
+            open_autonomy_dir=open_autonomy_dir,
         )
         self.resources: List[str] = []
 
@@ -189,7 +191,11 @@ class KubernetesGenerator(BaseDeploymentGenerator):
     ) -> "KubernetesGenerator":
         """Write output to build dir"""
 
-        output = "---\n".join([self.output, cast(str, self.tendermint_job_config)])
+        if self.use_testnet:
+            output = "---\n".join([self.output, cast(str, self.tendermint_job_config)])
+        else:
+            output = self.output
+
         if not self.build_dir.is_dir():  # pragma: no cover
             self.build_dir.mkdir()
         with open(

--- a/autonomy/deploy/generators/kubernetes/base.py
+++ b/autonomy/deploy/generators/kubernetes/base.py
@@ -60,13 +60,13 @@ class KubernetesGenerator(BaseDeploymentGenerator):
         packages_dir: Optional[Path] = None,
         open_aea_dir: Optional[Path] = None,
         open_autonomy_dir: Optional[Path] = None,
-        use_testnet: bool = False,
+        use_tm_testnet_setup: bool = False,
     ) -> None:
         """Initialise the deployment generator."""
         super().__init__(
             service_builder=service_builder,
             build_dir=build_dir,
-            use_testnet=use_testnet,
+            use_tm_testnet_setup=use_tm_testnet_setup,
             dev_mode=dev_mode,
             packages_dir=packages_dir,
             open_aea_dir=open_aea_dir,
@@ -191,7 +191,7 @@ class KubernetesGenerator(BaseDeploymentGenerator):
     ) -> "KubernetesGenerator":
         """Write output to build dir"""
 
-        if self.use_testnet:
+        if self.use_tm_testnet_setup:
             output = "---\n".join([self.output, cast(str, self.tendermint_job_config)])
         else:
             output = self.output

--- a/docs/api/cli/deploy.md
+++ b/docs/api/cli/deploy.md
@@ -101,16 +101,18 @@ Deploy an agent service.
     help="Include an ACN node in the deployment setup.",
 )
 @click.option(
-    "--use-testnet",
+    "-ltm",
+    "--local-tm-setup",
+    "use_tm_testnet_setup",
     is_flag=True,
     default=False,
-    help="Use tendermint testnet setup.",
+    help="Use local tendermint chain setup.",
 )
 @click.option("--image-version", type=str, help="Define runtime image version.")
 @registry_flag()
 @password_option(confirmation_prompt=True)
 @click.pass_context
-def build_deployment_command(click_context: click.Context, keys_file: Optional[Path], deployment_type: str, output_dir: Optional[Path], dev_mode: bool, force_overwrite: bool, registry: str, number_of_agents: Optional[int] = None, password: Optional[str] = None, open_aea_dir: Optional[Path] = None, packages_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, log_level: str = INFO, aev: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False, use_testnet: bool = False) -> None
+def build_deployment_command(click_context: click.Context, keys_file: Optional[Path], deployment_type: str, output_dir: Optional[Path], dev_mode: bool, force_overwrite: bool, registry: str, number_of_agents: Optional[int] = None, password: Optional[str] = None, open_aea_dir: Optional[Path] = None, packages_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, log_level: str = INFO, aev: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False, use_tm_testnet_setup: bool = False) -> None
 ```
 
 Build deployment setup for n agents.

--- a/docs/api/cli/deploy.md
+++ b/docs/api/cli/deploy.md
@@ -100,11 +100,17 @@ Deploy an agent service.
     default=False,
     help="Include an ACN node in the deployment setup.",
 )
+@click.option(
+    "--use-testnet",
+    is_flag=True,
+    default=False,
+    help="Use tendermint testnet setup.",
+)
 @click.option("--image-version", type=str, help="Define runtime image version.")
 @registry_flag()
 @password_option(confirmation_prompt=True)
 @click.pass_context
-def build_deployment_command(click_context: click.Context, keys_file: Optional[Path], deployment_type: str, output_dir: Optional[Path], dev_mode: bool, force_overwrite: bool, registry: str, number_of_agents: Optional[int] = None, password: Optional[str] = None, open_aea_dir: Optional[Path] = None, packages_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, log_level: str = INFO, aev: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False) -> None
+def build_deployment_command(click_context: click.Context, keys_file: Optional[Path], deployment_type: str, output_dir: Optional[Path], dev_mode: bool, force_overwrite: bool, registry: str, number_of_agents: Optional[int] = None, password: Optional[str] = None, open_aea_dir: Optional[Path] = None, packages_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, log_level: str = INFO, aev: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False, use_testnet: bool = False) -> None
 ```
 
 Build deployment setup for n agents.

--- a/docs/api/cli/helpers/deployment.md
+++ b/docs/api/cli/helpers/deployment.md
@@ -19,7 +19,7 @@ Run deployment.
 #### build`_`deployment
 
 ```python
-def build_deployment(keys_file: Path, build_dir: Path, deployment_type: str, dev_mode: bool, force_overwrite: bool, number_of_agents: Optional[int] = None, password: Optional[str] = None, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, multisig_address: Optional[str] = None, log_level: str = INFO, apply_environment_variables: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False) -> None
+def build_deployment(keys_file: Path, build_dir: Path, deployment_type: str, dev_mode: bool, force_overwrite: bool, number_of_agents: Optional[int] = None, password: Optional[str] = None, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, multisig_address: Optional[str] = None, log_level: str = INFO, apply_environment_variables: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False, use_testnet: bool = False) -> None
 ```
 
 Build deployment.

--- a/docs/api/cli/helpers/deployment.md
+++ b/docs/api/cli/helpers/deployment.md
@@ -19,7 +19,7 @@ Run deployment.
 #### build`_`deployment
 
 ```python
-def build_deployment(keys_file: Path, build_dir: Path, deployment_type: str, dev_mode: bool, force_overwrite: bool, number_of_agents: Optional[int] = None, password: Optional[str] = None, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, multisig_address: Optional[str] = None, log_level: str = INFO, apply_environment_variables: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False, use_testnet: bool = False) -> None
+def build_deployment(keys_file: Path, build_dir: Path, deployment_type: str, dev_mode: bool, force_overwrite: bool, number_of_agents: Optional[int] = None, password: Optional[str] = None, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, multisig_address: Optional[str] = None, log_level: str = INFO, apply_environment_variables: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False, use_tm_testnet_setup: bool = False) -> None
 ```
 
 Build deployment.

--- a/docs/api/deploy/base.md
+++ b/docs/api/deploy/base.md
@@ -175,7 +175,7 @@ Base Deployment Class.
 #### `__`init`__`
 
 ```python
-def __init__(service_builder: ServiceBuilder, build_dir: Path, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None)
+def __init__(service_builder: ServiceBuilder, build_dir: Path, use_testnet: bool = False, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None)
 ```
 
 Initialise with only kwargs.

--- a/docs/api/deploy/base.md
+++ b/docs/api/deploy/base.md
@@ -175,7 +175,7 @@ Base Deployment Class.
 #### `__`init`__`
 
 ```python
-def __init__(service_builder: ServiceBuilder, build_dir: Path, use_testnet: bool = False, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None)
+def __init__(service_builder: ServiceBuilder, build_dir: Path, use_tm_testnet_setup: bool = False, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None)
 ```
 
 Initialise with only kwargs.

--- a/docs/api/deploy/build.md
+++ b/docs/api/deploy/build.md
@@ -9,7 +9,7 @@ Script for generating deployment environments.
 #### generate`_`deployment
 
 ```python
-def generate_deployment(type_of_deployment: str, keys_file: Path, service_path: Path, build_dir: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, multisig_address: Optional[str] = None, log_level: str = INFO, apply_environment_variables: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False) -> str
+def generate_deployment(type_of_deployment: str, keys_file: Path, service_path: Path, build_dir: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, multisig_address: Optional[str] = None, log_level: str = INFO, apply_environment_variables: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False, use_testnet: bool = False) -> str
 ```
 
 Generate the deployment for the service.

--- a/docs/api/deploy/build.md
+++ b/docs/api/deploy/build.md
@@ -9,7 +9,7 @@ Script for generating deployment environments.
 #### generate`_`deployment
 
 ```python
-def generate_deployment(type_of_deployment: str, keys_file: Path, service_path: Path, build_dir: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, multisig_address: Optional[str] = None, log_level: str = INFO, apply_environment_variables: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False, use_testnet: bool = False) -> str
+def generate_deployment(type_of_deployment: str, keys_file: Path, service_path: Path, build_dir: Path, number_of_agents: Optional[int] = None, private_keys_password: Optional[str] = None, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, agent_instances: Optional[List[str]] = None, multisig_address: Optional[str] = None, log_level: str = INFO, apply_environment_variables: bool = False, image_version: Optional[str] = None, use_hardhat: bool = False, use_acn: bool = False, use_tm_testnet_setup: bool = False) -> str
 ```
 
 Generate the deployment for the service.

--- a/docs/api/deploy/generators/kubernetes/base.md
+++ b/docs/api/deploy/generators/kubernetes/base.md
@@ -19,7 +19,7 @@ Kubernetes Deployment Generator.
 #### `__`init`__`
 
 ```python
-def __init__(service_builder: ServiceBuilder, build_dir: Path, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None) -> None
+def __init__(service_builder: ServiceBuilder, build_dir: Path, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, use_testnet: bool = False) -> None
 ```
 
 Initialise the deployment generator.

--- a/docs/api/deploy/generators/kubernetes/base.md
+++ b/docs/api/deploy/generators/kubernetes/base.md
@@ -19,7 +19,7 @@ Kubernetes Deployment Generator.
 #### `__`init`__`
 
 ```python
-def __init__(service_builder: ServiceBuilder, build_dir: Path, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, use_testnet: bool = False) -> None
+def __init__(service_builder: ServiceBuilder, build_dir: Path, dev_mode: bool = False, packages_dir: Optional[Path] = None, open_aea_dir: Optional[Path] = None, open_autonomy_dir: Optional[Path] = None, use_tm_testnet_setup: bool = False) -> None
 ```
 
 Initialise the deployment generator.

--- a/tests/test_autonomy/test_cli/test_deploy/test_build/test_deployment.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_build/test_deployment.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022 Valory AG
+#   Copyright 2022-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tests/test_autonomy/test_cli/test_deploy/test_build/test_deployment.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_build/test_deployment.py
@@ -158,7 +158,7 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
                     str(self.t / DEFAULT_BUILD_FOLDER),
                     "--force",
                     "--local",
-                    "--use-testnet",
+                    "--local-tm-setup",
                 )
             )
 
@@ -553,7 +553,7 @@ class TestKubernetesBuild(BaseDeployBuildTest):
                     "--force",
                     "--local",
                     "--kubernetes",
-                    "--use-testnet",
+                    "--local-tm-setup",
                 )
             )
 

--- a/tests/test_deployments/test_deployments.py
+++ b/tests/test_deployments/test_deployments.py
@@ -207,14 +207,14 @@ class BaseDeploymentTests(ABC, CleanDirectoryClass):
         return str(self.working_dir / TEST_DEPLOYMENT_PATH)
 
     def load_deployer_and_app(
-        self, app: str, deployer: BaseDeploymentGenerator
+        self, app: str, deployer: BaseDeploymentGenerator, **kwargs: Any
     ) -> Tuple[BaseDeploymentGenerator, ServiceBuilder]:
         """Handles loading the 2 required instances"""
         app_instance = ServiceBuilder.from_dir(
             path=Path(app).parent,
             keys_file=DEFAULT_KEY_PATH,
         )
-        instance = deployer(service_builder=app_instance, build_dir=self.temp_dir.name)  # type: ignore
+        instance = deployer(service_builder=app_instance, build_dir=self.temp_dir.name, **kwargs)  # type: ignore
         return instance, app_instance
 
 
@@ -322,7 +322,7 @@ class TestTendermintDeploymentGenerators(BaseDeploymentTests):
             for spec in get_valid_deployments():
                 spec_path = self.write_deployment(spec)
                 deployer_instance, app_instance = self.load_deployer_and_app(
-                    spec_path, deployment_generator
+                    spec_path, deployment_generator, use_testnet=True
                 )
                 res = deployer_instance.generate_config_tendermint()  # type: ignore
                 assert (

--- a/tests/test_deployments/test_deployments.py
+++ b/tests/test_deployments/test_deployments.py
@@ -322,7 +322,7 @@ class TestTendermintDeploymentGenerators(BaseDeploymentTests):
             for spec in get_valid_deployments():
                 spec_path = self.write_deployment(spec)
                 deployer_instance, app_instance = self.load_deployer_and_app(
-                    spec_path, deployment_generator, use_testnet=True
+                    spec_path, deployment_generator, use_tm_testnet_setup=True
                 )
                 res = deployer_instance.generate_config_tendermint()  # type: ignore
                 assert (


### PR DESCRIPTION
## Proposed changes

This PR updated the deployment generator to make the usage of the tendermint testnet optional. By default the deployment generator won't include the testnet in the deployment build. You can enable it by using `-ltm/--local-tm-setup` flag

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
