### PR TITLE
fix: remove `.hypothesis` before running generators [no ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,18 +32,21 @@ clean-pyc:
 	find . -name '.DS_Store' -exec rm -fr {} +
 
 .PHONY: clean-test
-clean-test:
+clean-test: clean-cache
 	rm -fr .tox/
 	rm -f .coverage
 	find . -name ".coverage*" -not -name ".coveragerc" -exec rm -fr "{}" \;
 	rm -fr coverage.xml
 	rm -fr htmlcov/
-	rm -fr .hypothesis
-	rm -fr .pytest_cache
-	rm -fr .mypy_cache/
-	rm -fr .hypothesis/
 	find . -name 'log.txt' -exec rm -fr {} +
 	find . -name 'log.*.txt' -exec rm -fr {} +
+
+# removes various cache files
+.PHONY: clean-cache
+clean-cache:
+	rm -fr .hypothesis/
+	rm -fr .pytest_cache
+	rm -fr .mypy_cache/
 
 # isort: fix import orders
 # black: format files according to the pep standards
@@ -76,7 +79,7 @@ security:
 # generate docs for updated packages
 # fix hashes in docs
 .PHONY: generators
-generators:
+generators: clean-cache
 	tox -e abci-docstrings
 	tox -e fix-copyright
 	tox -e lock-packages


### PR DESCRIPTION
## Fixes

This PR fixes https://github.com/valory-xyz/open-autonomy/issues/1374 by removing `.hypothesis` before running generators.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
