### PR TITLE
chore: warn when no strict_check_strings are provided

### DIFF
--- a/plugins/aea-test-autonomy/aea_test_autonomy/base_test_classes/agents.py
+++ b/plugins/aea-test-autonomy/aea_test_autonomy/base_test_classes/agents.py
@@ -319,6 +319,8 @@ class BaseTestEnd2End(AEATestCaseMany, UseFlaskTendermintNode, UseLocalIpfs):
         :return: tuple with two lists of missed strings, the strict and the round respectively.
         """
         # Call the original method with the strict checks.
+        if len(strict_check_strings) == 0:
+            logging.warning("No strict check strings provided.")
         kwargs["strings"] = strict_check_strings
         kwargs["is_terminating"] = False
         missing_strict_strings = super().missing_from_output(**kwargs)


### PR DESCRIPTION
## Proposed changes

This PR fixes https://github.com/valory-xyz/open-autonomy/issues/1186 by warning the user when no strict check strings are provided. 

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
