### PR TITLE
[0.9.1] Fix the usage of internal host gateway on the `docker-compose`

### DIFF
--- a/autonomy/deploy/generators/docker_compose/templates.py
+++ b/autonomy/deploy/generators/docker_compose/templates.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021-2022 Valory AG
+#   Copyright 2021-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/autonomy/deploy/generators/docker_compose/templates.py
+++ b/autonomy/deploy/generators/docker_compose/templates.py
@@ -112,6 +112,8 @@ ABCI_NODE_TEMPLATE: str = """
     networks:
       localnet:
         ipv4_address: 192.167.11.{localnet_address_postfix}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./persistent_data/logs:/logs:Z
       - ./agent_keys/agent_{node_id}:/agent_key:Z


### PR DESCRIPTION
## Proposed changes

This PR enables the usage of `host.docker.internal` as machine host gateway in docker compose settings

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
