### PR TITLE
[0.10.0]: Set the requests equal to the limits for the resources

### DIFF
--- a/autonomy/deploy/generators/kubernetes/templates.py
+++ b/autonomy/deploy/generators/kubernetes/templates.py
@@ -204,11 +204,11 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            memory: "1512Mi"
-            cpu: "1"
+            memory: "350Mi"
+            cpu: "0.05"
           requests:
-            cpu: "1"
-            memory: "1512Mi"
+            cpu: "0.05"
+            memory: "350Mi"
         ports:
           - containerPort: 26656
           - containerPort: 26657
@@ -243,9 +243,9 @@ spec:
         resources:
           limits:
             memory: "1512Mi"
-            cpu: "1"
+            cpu: "0.5"
           requests:
-            cpu: "1"
+            cpu: "0.5"
             memory: "1512Mi"
         env:
           - name: HOSTNAME

--- a/autonomy/deploy/generators/kubernetes/templates.py
+++ b/autonomy/deploy/generators/kubernetes/templates.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2021-2022 Valory AG
+#   Copyright 2021-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -207,8 +207,8 @@ spec:
             memory: "1512Mi"
             cpu: "1"
           requests:
-            cpu: "0.05"
-            memory: "128Mi"
+            cpu: "1"
+            memory: "1512Mi"
         ports:
           - containerPort: 26656
           - containerPort: 26657
@@ -245,8 +245,8 @@ spec:
             memory: "1512Mi"
             cpu: "1"
           requests:
-            cpu: "0.05"
-            memory: "128Mi"
+            cpu: "1"
+            memory: "1512Mi"
         env:
           - name: HOSTNAME
             value: "agent-node-{validator_ix}"


### PR DESCRIPTION
## Proposed changes

This will ensure that an agent will never try to use more resources than expected. By setting `requests=limits`, then assuming all the agents in the pod are using the max allowed resources at some point, we still do not utilize more than the pod has available.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

n/a