### PR TITLE
Add support for kubernetes builds on the `from-token` deployments

### DIFF
--- a/autonomy/cli/deploy.py
+++ b/autonomy/cli/deploy.py
@@ -266,6 +266,24 @@ def run(build_dir: Path, no_recreate: bool, remove_orphans: bool) -> None:
     default=False,
     help="Apply environment variable when loading service config.",
 )
+@click.option(
+    "--docker",
+    "deployment_type",
+    flag_value=DockerComposeGenerator.deployment_type,
+    default=True,
+    help="Use docker as a backend.",
+)
+@click.option(
+    "--kubernetes",
+    "deployment_type",
+    flag_value=KubernetesGenerator.deployment_type,
+    help="Use kubernetes as a backend.",
+)
+@click.option(
+    "--no-deploy",
+    is_flag=True,
+    help="If set to true, the deployment won't run automatically",
+)
 @chain_selection_flag(help_string_format="Use {} chain to resolve the token id.")
 @click.pass_context
 @password_option(confirmation_prompt=True)
@@ -276,6 +294,8 @@ def run_deployment_from_token(  # pylint: disable=too-many-arguments, too-many-l
     chain_type: ChainType,
     skip_image: bool,
     n: Optional[int],
+    deployment_type: str,
+    no_deploy: bool,
     aev: bool = False,
     password: Optional[str] = None,
 ) -> None:
@@ -294,6 +314,8 @@ def run_deployment_from_token(  # pylint: disable=too-many-arguments, too-many-l
             chain_type=ChainType(chain_type),
             skip_image=skip_image,
             n=n,
+            deployment_type=deployment_type,
             aev=aev,
             password=password,
+            no_deploy=no_deploy,
         )

--- a/autonomy/cli/helpers/deployment.py
+++ b/autonomy/cli/helpers/deployment.py
@@ -50,7 +50,7 @@ from autonomy.deploy.constants import (
     TM_STATE_DIR,
     VENVS_DIR,
 )
-from autonomy.deploy.generators.docker_compose.base import DockerComposeGenerator
+from autonomy.deploy.generators.kubernetes.base import KubernetesGenerator
 from autonomy.deploy.image import build_image
 
 
@@ -221,8 +221,10 @@ def build_and_deploy_from_token(  # pylint: disable=too-many-arguments, too-many
     chain_type: ChainType,
     skip_image: bool,
     n: Optional[int],
+    deployment_type: str,
     aev: bool = False,
     password: Optional[str] = None,
+    no_deploy: bool = False,
 ) -> None:
     """Build and run deployment from tokenID."""
 
@@ -247,7 +249,7 @@ def build_and_deploy_from_token(  # pylint: disable=too-many-arguments, too-many
         build_deployment(
             keys_file=keys_file,
             build_dir=build_dir,
-            deployment_type=DockerComposeGenerator.deployment_type,
+            deployment_type=deployment_type,
             dev_mode=False,
             force_overwrite=True,
             number_of_agents=n,
@@ -263,4 +265,8 @@ def build_and_deploy_from_token(  # pylint: disable=too-many-arguments, too-many
             build_image(agent=service.agent)
 
     click.echo("Service build successful.")
+    if no_deploy or deployment_type == KubernetesGenerator.deployment_type:
+        return
+
+    click.echo("Running deployment")
     run_deployment(build_dir)

--- a/docs/api/cli/deploy.md
+++ b/docs/api/cli/deploy.md
@@ -186,6 +186,24 @@ Run deployment.
     default=False,
     help="Apply environment variable when loading service config.",
 )
+@click.option(
+    "--docker",
+    "deployment_type",
+    flag_value=DockerComposeGenerator.deployment_type,
+    default=True,
+    help="Use docker as a backend.",
+)
+@click.option(
+    "--kubernetes",
+    "deployment_type",
+    flag_value=KubernetesGenerator.deployment_type,
+    help="Use kubernetes as a backend.",
+)
+@click.option(
+    "--no-deploy",
+    is_flag=True,
+    help="If set to true, the deployment won't run automatically",
+)
 @chain_selection_flag(
     help_string_format="Use {} chain to resolve the token id.")
 @click.pass_context
@@ -196,6 +214,8 @@ def run_deployment_from_token(click_context: click.Context,
                               chain_type: ChainType,
                               skip_image: bool,
                               n: Optional[int],
+                              deployment_type: str,
+                              no_deploy: bool,
                               aev: bool = False,
                               password: Optional[str] = None) -> None
 ```

--- a/docs/api/cli/helpers/deployment.md
+++ b/docs/api/cli/helpers/deployment.md
@@ -55,8 +55,10 @@ def build_and_deploy_from_token(token_id: int,
                                 chain_type: ChainType,
                                 skip_image: bool,
                                 n: Optional[int],
+                                deployment_type: str,
                                 aev: bool = False,
-                                password: Optional[str] = None) -> None
+                                password: Optional[str] = None,
+                                no_deploy: bool = False) -> None
 ```
 
 Build and run deployment from tokenID.

--- a/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
@@ -152,7 +152,7 @@ class TestFromToken(BaseChainInteractionTest):
         with mock.patch(
             "autonomy.cli.helpers.deployment.fetch_service_ipfs",
             return_value=service_dir,
-        ), run_deployment_patch, build_image_patch, default_remote_registry_patch, default_ipfs_node_patch, ipfs_resolve_patch:
+        ), run_deployment_patch as rdp, build_image_patch, default_remote_registry_patch, default_ipfs_node_patch, ipfs_resolve_patch:
             result = self.run_cli(
                 (str(self.token), str(self.keys_file), "--kubernetes")
             )
@@ -162,6 +162,9 @@ class TestFromToken(BaseChainInteractionTest):
             assert "Building required images" in result.stdout
             assert "Service build successful" in result.stdout
             assert "Type:                 kubernetes" in result.stdout
+            assert "Running deployment" not in result.output
+
+            rdp.assert_not_called()
 
         assert (self.t / "service" / "abci_build" / "build.yaml").exists()
 

--- a/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
@@ -161,6 +161,7 @@ class TestFromToken(BaseChainInteractionTest):
             assert "Service name: valory/oracle_hardhat" in result.stdout
             assert "Building required images" in result.stdout
             assert "Service build successful" in result.stdout
+            assert "Type:                 kubernetes" in result.stdout
 
         assert (self.t / "service" / "abci_build" / "build.yaml").exists()
 

--- a/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
@@ -130,6 +130,40 @@ class TestFromToken(BaseChainInteractionTest):
             assert "Building required images" in result.stdout
             assert "Service build successful" in result.stdout
 
+    def test_from_token_kubernetes(
+        self,
+    ) -> None:
+        """Run test."""
+
+        service_dir = self.t / "service"
+        service_dir.mkdir()
+
+        service_file = service_dir / "service.yaml"
+        service_file.write_text(
+            (
+                ROOT_DIR
+                / "tests"
+                / "data"
+                / "dummy_service_config_files"
+                / "service_0.yaml"
+            ).read_text()
+        )
+
+        with mock.patch(
+            "autonomy.cli.helpers.deployment.fetch_service_ipfs",
+            return_value=service_dir,
+        ), run_deployment_patch, build_image_patch, default_remote_registry_patch, default_ipfs_node_patch, ipfs_resolve_patch:
+            result = self.run_cli(
+                (str(self.token), str(self.keys_file), "--kubernetes")
+            )
+
+            assert result.exit_code == 0, result.stdout
+            assert "Service name: valory/oracle_hardhat" in result.stdout
+            assert "Building required images" in result.stdout
+            assert "Service build successful" in result.stdout
+
+        assert (self.t / "service" / "abci_build" / "build.yaml").exists()
+
     def test_fail_on_chain_resolve_connection_error(self) -> None:
         """Run test."""
 


### PR DESCRIPTION
## Proposed changes

This PR adds support for kubernetes builds on the `from-token` deployments using `--kubernetes` flag as well as adds support for specifying whether the deployment should run directly or not using `--no-deploy` flag

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
