### PR TITLE
Add warning if the termination skill is missing as a dependency

### DIFF
--- a/autonomy/analyse/service.py
+++ b/autonomy/analyse/service.py
@@ -183,7 +183,7 @@ ABCI_SKILL_MODEL_PARAMS_SCHEMA = {
 
 ABCI = "abci"
 LEDGER = "ledger"
-
+TERMINATION_ABCI = PublicId(author="valory", name="termination_abci", version="any")
 ENV_VAR_RE = re.compile(
     r"^\$\{(?P<name>[A-Z_0-9]+)?:?(?P<type>bool|int|float|str|list|dict)?:?(?P<value>.+)?\}$"
 )
@@ -728,6 +728,13 @@ class ServiceAnalyser:
                         )
                     )
 
+    def _check_for_termination_abci_skill(self, dependencies: Set[PublicId]) -> None:
+        """Check termination ABCI skill is an dependency for the agent"""
+        for dependency in dependencies:
+            if dependency.to_any() == TERMINATION_ABCI:
+                return
+        self.logger.warning("Termination skill is not defined as a dependency")
+
     def validate_skill_config(self, skill_config: SkillConfig) -> None:
         """Check required overrides."""
 
@@ -744,6 +751,7 @@ class ServiceAnalyser:
             has_multiple_overrides=False,
             error_message="ABCI skill validation failed; {error}",
         )
+        self._check_for_termination_abci_skill(skill_config.skills)
         self.logger.info("No issues found in the ABCI skill configuration")
 
     def validate_agent_overrides(self, agent_config: AgentConfig) -> None:
@@ -770,7 +778,7 @@ class ServiceAnalyser:
                 "Agent overrides validation failed with following errors"
                 f"\n\t- {error_string}"
             )
-
+        self._check_for_termination_abci_skill(agent_config.skills)
         self.logger.info("No issues found in the agent overrides")
 
     def validate_service_overrides(self) -> None:

--- a/tests/test_autonomy/test_cli/test_analyse/test_verify_service.py
+++ b/tests/test_autonomy/test_cli/test_analyse/test_verify_service.py
@@ -855,7 +855,7 @@ class TestCheckOnChainState(BaseAnalyseServiceTest):
 class TestCheckSuccessful(BaseAnalyseServiceTest):
     """Test a successful check"""
 
-    def test_run(self) -> None:
+    def test_run(self, caplog: Any) -> None:
         """Test run."""
 
         skill_config = get_dummy_overrides_skill(env_vars_with_name=True)
@@ -900,8 +900,11 @@ class TestCheckSuccessful(BaseAnalyseServiceTest):
         ), self.patch_get_on_chain_service_id(), mock.patch(
             "autonomy.analyse.service.get_service_info",
             return_value=(None, 4, None),
+        ), caplog.at_level(
+            logging.WARNING
         ):
             result = self.run_cli(commands=self.token_id_option)
 
         assert result.exit_code == 0, result.stderr
         assert "Service is ready to be deployed" in result.output
+        assert "Termination skill is not defined as a dependency" in caplog.text

--- a/tests/test_autonomy/test_cli/test_helpers/test_fsm_spec.py
+++ b/tests/test_autonomy/test_cli/test_helpers/test_fsm_spec.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022 Valory AG
+#   Copyright 2022-2023 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Proposed changes

This PR updates the service analyser to warn if the termination skill is not defined as a dependency in the agent and the ABCI skill

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes
- [ ] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [ ] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.