### PR TITLE
Bumps open-aea and open-autonomy to latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,3 +153,4 @@ if __name__ == "__main__":
             "Source": "https://github.com/valory/open-autonomy",
         },
     )
+


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.49.0
- Bumps open-aea-ledger-ethereum to ==1.49.0
- Bumps open-aea-ledger-ethereum-flashbots to ==1.49.0
- Bumps open-aea-ledger-ethereum-hwi to ==1.49.0
- Bumps open-aea-ledger-cosmos to ==1.49.0
- Bumps open-aea-ledger-solana to ==1.49.0
- Bumps open-aea-cli-ipfs to ==1.49.0
- Bumps open-autonomy to ==0.14.8
- Bumps open-aea-test-autonomy to ==0.14.8