### PR TITLE
Fix: Add a small hash id in build_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -418,7 +418,7 @@ autonomy/data/contracts/service_registry_token_utility
 
 generate_abciapp_spec.py
 generate_abci_docstrings
-abci_build/
+abci_build_*
 keys.json
 leak_report
 temp/

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ protolint_install_win:
 	powershell -command '$$env:GO111MODULE="on"; go install github.com/yoheimuta/protolint/cmd/protolint@v0.27.0'
 
 teardown-docker-compose:
-	cd abci_build/ && \
+	cd $(find . -type d -name "abci_build*" | head -1) && \
 		docker-compose kill && \
 		docker-compose down && \
 		echo "Deployment torndown!" && \

--- a/autonomy/cli/deploy.py
+++ b/autonomy/cli/deploy.py
@@ -38,6 +38,7 @@ from autonomy.chain.config import ChainType
 from autonomy.cli.helpers.deployment import (
     build_and_deploy_from_token,
     build_deployment,
+    build_hash_id,
     run_deployment,
     stop_deployment,
 )
@@ -245,7 +246,9 @@ def build_deployment_command(  # pylint: disable=too-many-arguments, too-many-lo
         message = f"No such file or directory: {keys_file}. Please provide valid path for keys file."
         raise click.ClickException(message)
 
-    build_dir = Path(output_dir or DEFAULT_BUILD_FOLDER).absolute()
+    build_dir = Path(
+        output_dir or DEFAULT_BUILD_FOLDER.format(build_hash_id())
+    ).absolute()
     if dev_mode:
         packages_dir = _validate_packages_path(path=packages_dir)
         open_aea_dir = _validate_open_aea_dir(path=open_aea_dir)

--- a/autonomy/cli/helpers/deployment.py
+++ b/autonomy/cli/helpers/deployment.py
@@ -21,6 +21,7 @@
 import os
 import shutil
 import time
+from base64 import urlsafe_b64encode
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -110,6 +111,11 @@ def _load_compose_project(build_dir: Path) -> Project:
                 "please use `--aev` flag if you intend to use environment variables."
             )
         raise
+
+
+def build_hash_id() -> str:
+    """Generate a random 4 character hash id for the deployment build directory name."""
+    return urlsafe_b64encode(bytes(os.urandom(3))).decode()
 
 
 def run_deployment(
@@ -300,7 +306,7 @@ def build_and_deploy_from_token(  # pylint: disable=too-many-arguments, too-many
     *_, service_hash = service_metadata["code_uri"].split("//")
     public_id = PublicId(author="valory", name="service", package_hash=service_hash)
     service_path = fetch_service_ipfs(public_id)
-    build_dir = service_path / DEFAULT_BUILD_FOLDER
+    build_dir = service_path / DEFAULT_BUILD_FOLDER.format(build_hash_id())
 
     with cd(service_path):
         build_deployment(

--- a/autonomy/cli/replay.py
+++ b/autonomy/cli/replay.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022 Valory AG
+#   Copyright 2024 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import click
 from aea.cli.utils.click_utils import reraise_as_click_exception
 from aea.configurations.constants import PACKAGES
 
+from autonomy.cli.helpers.deployment import build_hash_id
 from autonomy.constants import DEFAULT_BUILD_FOLDER, DOCKER_COMPOSE_YAML
 from autonomy.deploy.constants import PERSISTENT_DATA_DIR, TM_STATE_DIR
 from autonomy.replay.agent import AgentRunner
@@ -38,7 +39,6 @@ from autonomy.replay.utils import (
 
 
 REGISTRY_PATH = Path(PACKAGES)
-BUILD_DIR = Path(DEFAULT_BUILD_FOLDER)
 
 
 @click.group(name="replay")
@@ -52,7 +52,7 @@ def replay_group() -> None:
     "--build",
     "build_path",
     type=click.Path(exists=True, dir_okay=True),
-    default=BUILD_DIR,
+    default=Path(DEFAULT_BUILD_FOLDER.format(build_hash_id())),
     help="Path to build dir.",
 )
 @click.option(
@@ -86,7 +86,7 @@ def run_agent(agent: int, build_path: Path, registry_path: Path) -> None:
     "--build",
     "build_dir",
     type=click.Path(dir_okay=True, exists=True),
-    default=BUILD_DIR,
+    default=Path(DEFAULT_BUILD_FOLDER.format(build_hash_id())),
     help="Path to build directory.",
 )
 def run_tendermint(build_dir: Path) -> None:

--- a/autonomy/constants.py
+++ b/autonomy/constants.py
@@ -22,7 +22,7 @@ import os
 from autonomy.__version__ import __version__ as DEFAULT_AUTONOMY_VERSION
 
 
-DEFAULT_BUILD_FOLDER = "abci_build"
+DEFAULT_BUILD_FOLDER = "abci_build_{}"
 DEFAULT_KEYS_FILE = "keys.json"
 DEFAULT_IMAGE_VERSION = "latest"
 SERVICE_REGISTRY_CONTRACT_CONTAINER_NAME = "autonolas-registries"

--- a/docs/advanced_reference/commands/autonomy_analyse.md
+++ b/docs/advanced_reference/commands/autonomy_analyse.md
@@ -298,18 +298,18 @@ autonomy analyse benchmarks [OPTIONS] PATH
 
 ### Examples
 
-The benchmark data will be stored in the folder `<service_folder>/abci_build/persistent_data/benchmarks`.
+The benchmark data will be stored in the folder `<service_folder>/abci_build_hAsH/persistent_data/benchmarks`.
 
 To aggregate stats for all periods, execute:
 
 ```bash
-autonomy analyse benchmarks abci_build/persistent_data/benchmarks
+autonomy analyse benchmarks abci_build_hAsH/persistent_data/benchmarks
 ```
 
 To aggregate stats for `consensus` block type in the second period, execute:
 
 ```bash
-    autonomy analyse benchmarks abci_build/persistent_data/benchmarks --period 2 --block-type consensus
+    autonomy analyse benchmarks abci_build_hAsH/persistent_data/benchmarks --period 2 --block-type consensus
 ```
 
 ## `autonomy analyse service`

--- a/docs/advanced_reference/commands/autonomy_deploy.md
+++ b/docs/advanced_reference/commands/autonomy_deploy.md
@@ -41,7 +41,7 @@ autonomy deploy --env-file <path_to_json> COMMAND [ARGS]
 
 Build a service deployment.
 
-This command must be executed within a service folder. That is, a folder containing the service configuration file (`service.yaml`). The deployment will be created in the subfolder `./abci_build`.
+This command must be executed within a service folder. That is, a folder containing the service configuration file (`service.yaml`). The deployment will be created in the subfolder `./abci_build_*`.
 
 ### Usage
 
@@ -201,7 +201,7 @@ on kubernetes deployment.
 
 Run a service deployment locally stored.
 
-This command is a wrapper around `docker-compose up` to run the service deployment. To execute this command you need to be located within the deployment environment subfolder (`./abci_build`), or specify it with the option `--build-dir`.
+This command is a wrapper around `docker-compose up` to run the service deployment. To execute this command you need to be located within the deployment environment subfolder (`./abci_build_*`), or specify it with the option `--build-dir`.
 
 ### Usage
 
@@ -229,16 +229,16 @@ autonomy deploy run [OPTIONS]
 ### Examples
 
 ```bash
-autonomy deploy run --build-dir ./abci_build
+autonomy deploy run --build-dir ./abci_build_hAsH
 ```
 
-Runs the service deployment stored locally in the directory `./abci_build`.
+Runs the service deployment stored locally in the directory `./abci_build_hAsH`.
 
 To provide password for the private keys
 
 ```bash
 export OPEN_AUTONOMY_PRIVATE_KEY_PASSWORD=PASSWORD
-autonomy deploy run --build-dir ./abci_build
+autonomy deploy run --build-dir ./abci_build_hAsH
 ```
 
 ## `autonomy deploy from-token`

--- a/docs/advanced_reference/developer_tooling/benchmarking.md
+++ b/docs/advanced_reference/developer_tooling/benchmarking.md
@@ -88,7 +88,7 @@ As a summary, the sequence of events that should occur so that the benchmark inf
 3. The {{fsm_app}} reaches the `ResetAndPauseRound` (`reset_pause_abci` round and calls the `BenchmarkTool.save()` method.
 4. Wait for as many periods as you wish before stopping the service. Note that any measurement not saved at the end of a period will be lost.
 
-The benchmark data will be stored in the folder `<service_folder>/abci_build/persistent_data/benchmarks`.
+The benchmark data will be stored in the folder `<service_folder>/abci_build_*/persistent_data/benchmarks`.
 
 ## Use the command line to aggregate benchmark information
 
@@ -96,17 +96,17 @@ The benchmark data will be stored in the folder `<service_folder>/abci_build/per
 
 2. **Wait for service execution.** Wait until the service has completed at least one period before cancelling the execution. That is, wait until the `ResetAndPauseRound` round has occurred at least once. As commented above, this is required because benchmark data is saved in this state. Once you have a data dump, you can stop the local execution by pressing `Ctrl-C`.
 
-3. **Aggregate the benchmark data.** The benchmark data will be stored in the folder `<service_folder>/abci_build/persistent_data/benchmarks`. Aggregate the data for all periods executing:
+3. **Aggregate the benchmark data.** The benchmark data will be stored in the folder `<service_folder>/abci_build_*/persistent_data/benchmarks`. Aggregate the data for all periods executing:
 
     ```bash
-    autonomy analyse benchmarks abci_build/persistent_data/benchmarks
+    autonomy analyse benchmarks abci_build_*/persistent_data/benchmarks
     ```
 
     This will generate a `benchmarks.html` file containing benchmark stats in your current directory.
     By default the script will generate output for all periods but you can specify which period to generate output for. Similarly, block types aggregation is configurable as well. For example,
 
     ```bash
-    autonomy analyse benchmarks abci_build/persistent_data/benchmarks --period 2 --block-type consensus
+    autonomy analyse benchmarks abci_build_*/persistent_data/benchmarks --period 2 --block-type consensus
     ```
 
     will aggregate stats for `consensus` code blocks in the second period.

--- a/docs/advanced_reference/developer_tooling/debugging_in_the_cluster.md
+++ b/docs/advanced_reference/developer_tooling/debugging_in_the_cluster.md
@@ -24,8 +24,8 @@ Finally, build the deployment and run it:
 ```bash
 export OPEN_AUTONOMY_PRIVATE_KEY_PASSWORD=${PASSWORD}
 autonomy deploy build  ../generated_keys.json --kubernetes --dev
-kubectl apply -f abci_build/
-kubectl apply -f abci_build/agent_keys
+kubectl apply -f abci_build_*/
+kubectl apply -f abci_build_*/agent_keys
 ```
 
 This will deploy a private hardhat container to the cluster, along with the associated agent service, configured to use the hardhat container.

--- a/docs/advanced_reference/developer_tooling/dev_mode.md
+++ b/docs/advanced_reference/developer_tooling/dev_mode.md
@@ -22,7 +22,7 @@ Before starting this guide, ensure that your machine satisfies the framework req
     autonomy deploy build --dev --packages-dir ~/service/packages --open-aea-dir ~/git/open-aea/ --use-hardhat -ltm
     ```
 
-    This will create a deployment environment in `dev` mode within the `./abci_build` folder.
+    This will create a deployment environment in `dev` mode within the `./abci_build_*` folder.
   
     You must modify the paths in the command above appropriately, pointing to:
 
@@ -39,10 +39,10 @@ Before starting this guide, ensure that your machine satisfies the framework req
 
     > Note: When building development deployments you don't have to define keys manually, `autonomy` generates the keys automatically in development mode. You can still specify the keys file if you already have one and you're planning on using it.
 
-3. **Run the service.** Navigate to the deployment environment folder (`./abci_build`) and run the deployment locally.
+3. **Run the service.** Navigate to the deployment environment folder (`./abci_build_*`) and run the deployment locally.
 
     ```bash
-    cd abci_build
+    cd abci_build_*
     autonomy deploy run
     ```
 

--- a/docs/api/cli/helpers/deployment.md
+++ b/docs/api/cli/helpers/deployment.md
@@ -4,6 +4,16 @@
 
 Deployment helpers.
 
+<a id="autonomy.cli.helpers.deployment.build_hash_id"></a>
+
+#### build`_`hash`_`id
+
+```python
+def build_hash_id() -> str
+```
+
+Generate a random 4 character hash id for the deployment build directory name.
+
 <a id="autonomy.cli.helpers.deployment.run_deployment"></a>
 
 #### run`_`deployment

--- a/docs/api/cli/replay.md
+++ b/docs/api/cli/replay.md
@@ -26,7 +26,7 @@ Replay tools for agent services.
     "--build",
     "build_path",
     type=click.Path(exists=True, dir_okay=True),
-    default=BUILD_DIR,
+    default=Path(DEFAULT_BUILD_FOLDER.format(build_hash_id())),
     help="Path to build dir.",
 )
 @click.option(
@@ -51,7 +51,7 @@ Agent runner.
     "--build",
     "build_dir",
     type=click.Path(dir_okay=True, exists=True),
-    default=BUILD_DIR,
+    default=Path(DEFAULT_BUILD_FOLDER.format(build_hash_id())),
     help="Path to build directory.",
 )
 def run_tendermint(build_dir: Path) -> None

--- a/docs/application_deployment.md
+++ b/docs/application_deployment.md
@@ -57,7 +57,7 @@ Options:
 
 For example, in order to build a deployment from scratch for oracle abci, first ensure you have a clean build environment and then build the images:
 ```bash
-rm -rf abci_build
+rm -rf abci_build_*
 autonomy build-image valory/oracle_hardhat
 ```
 
@@ -66,12 +66,12 @@ Next, run the command to generate the relevant build configuration:
 autonomy deploy build deployments/keys/hardhat_keys.json
 ```
 
-A build configuration will be output to `./abci_build`.
+A build configuration will be output to `./abci_build_*/`.
 
 This can then be launched using the appropriate tool. For example, to launch a deployment using docker-compose.
 
 ```bash
-cd abci_build/
+cd abci_build_*/
 docker-compose up --force-recreate
 ```
 

--- a/docs/counter_example.md
+++ b/docs/counter_example.md
@@ -71,9 +71,9 @@ you have followed the [setup instructions](guides/quick_start.md#setup). As a re
     !!!note
         It is also possible to generate a deployment using a local service configuration. See the Commands section for the complete details.
 
-6. The build configuration will be located in `./abci_build`. Run the deployment using
+6. The build configuration will be located in `./abci_build_*`. Run the deployment using
     ```bash
-    cd abci_build
+    cd abci_build_*
     autonomy deploy run
     ```
 

--- a/docs/guides/deploy_service.md
+++ b/docs/guides/deploy_service.md
@@ -153,17 +153,17 @@ We illustrate the full local deployment workflow using the `hello_world` service
     === "Docker Compose"
 
         ```bash
-        rm -rf abci_build #(1)!
+        rm -rf abci_build_* #(1)!
         autonomy deploy build keys.json -ltm #(2)!
         ```
 
         1. Delete previous deployments, if necessary.
         2. `-ltm` stands for "use local Tendermint node". Check out the [`autonomy deploy build`](../../../advanced_reference/commands/autonomy_deploy/#autonomy-deploy-build) command documentation to learn more about its parameters and options.
 
-        This will create a deployment environment within the `./abci_build` folder with the following structure:
+        This will create a deployment environment within the `./abci_build_*` folder with the following structure:
 
         ```bash
-        abci_build/
+        abci_build_*/
         ├── agent_keys
         │   ├── agent_0
         │   ├── agent_1
@@ -185,17 +185,17 @@ We illustrate the full local deployment workflow using the `hello_world` service
     === "Kubernetes"
 
         ```bash
-        rm -rf abci_build #(1)!
+        rm -rf abci_build_* #(1)!
         autonomy deploy build keys.json -ltm --kubernetes #(2)!
         ```
 
         1. Delete previous deployments, if necessary.
         2. `-ltm` stands for "use local Tendermint node". Check out the [`autonomy deploy build`](../../../advanced_reference/commands/autonomy_deploy/#autonomy-deploy-build) command documentation to learn more about its parameters and options.
 
-        This will create a deployment environment within the `./abci_build` folder with the following structure:
+        This will create a deployment environment within the `./abci_build_*` folder with the following structure:
 
         ```
-        abci_build/
+        abci_build_*/
         ├── agent_keys
         │   ├── agent_0_private_key.yaml
         │   ├── agent_1_private_key.yaml
@@ -209,12 +209,12 @@ We illustrate the full local deployment workflow using the `hello_world` service
             └── venvs
         ```
 
-5. **Execute the deployment.** Navigate to the deployment environment folder (`./abci_build`) and run the deployment locally.
+5. **Execute the deployment.** Navigate to the deployment environment folder (`./abci_build_*`) and run the deployment locally.
 
     === "Docker Compose"
 
         ```bash
-        cd abci_build
+        cd abci_build_*
         autonomy deploy run #(1)!
         ```
 
@@ -231,7 +231,7 @@ We illustrate the full local deployment workflow using the `hello_world` service
 
         1. Create the minikube Kubernetes cluster.
             ```bash
-            cd abci_build
+            cd abci_build_*
             minikube start --driver=docker
             ```
 

--- a/docs/guides/quick_start.md
+++ b/docs/guides/quick_start.md
@@ -97,12 +97,12 @@ Before starting this guide, ensure that your machine satisfies the framework req
         autonomy deploy build keys.json -ltm
         ```
 
-        This command takes the configuration parameters specified inside the `service.yaml` and overrides them with the environment variables defined above. With the parameters defined, and the agent image ready, the output of this command is a Docker Compose deployment stored in the `abci_build` folder. The command takes care of configuring the necessary Tendermint images connected to each of the agents.
+        This command takes the configuration parameters specified inside the `service.yaml` and overrides them with the environment variables defined above. With the parameters defined, and the agent image ready, the output of this command is a Docker Compose deployment stored in the `abci_build_*` folder. The command takes care of configuring the necessary Tendermint images connected to each of the agents.
 
 4. Run the service:
 
     ```bash
-    cd abci_build
+    cd abci_build_*
     autonomy deploy run
     ```
 

--- a/tests/test_autonomy/test_cli/test_deploy/test_build/test_deployment.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_build/test_deployment.py
@@ -34,6 +34,7 @@ from aea_test_autonomy.configurations import (
     ETHEREUM_ENCRYPTION_PASSWORD,
 )
 
+from autonomy.cli.helpers.deployment import build_hash_id
 from autonomy.constants import DEFAULT_BUILD_FOLDER, DEFAULT_DOCKER_IMAGE_AUTHOR
 from autonomy.deploy.base import (
     DEFAULT_AGENT_CPU_LIMIT,
@@ -157,13 +158,13 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--local",
                 )
             )
@@ -185,13 +186,13 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--local",
                     "--local-tm-setup",
                 )
@@ -205,13 +206,13 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--local",
                     "--log-level",
                     DEBUG,
@@ -247,13 +248,13 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--dev",
                     "--local",
                     "--packages-dir",
@@ -298,30 +299,27 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
         keys_file = Path(ETHEREUM_ENCRYPTED_KEYS)
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
 
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--password",
                     ETHEREUM_ENCRYPTION_PASSWORD,
                     "--local",
                 )
             )
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
         assert result.exit_code == 0, result.stderr
         assert (
             "WARNING: `--password` flag has been deprecated, use `OPEN_AUTONOMY_PRIVATE_KEY_PASSWORD` to export the password value"
             in result.stdout
         )
         assert build_dir.exists()
-
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
         assert result.exit_code == 0, result.output
-        assert build_dir.exists()
 
         docker_compose_file = build_dir / DockerComposeGenerator.output_name
         with open(docker_compose_file, "r", encoding="utf-8") as fp:
@@ -353,12 +351,13 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--dev",
                     "--local",
                     "--packages-dir",
@@ -369,8 +368,6 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
                     "--use-acn",
                 )
             )
-
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
 
         assert result.exit_code == 0, result.output
         assert build_dir.exists()
@@ -391,7 +388,7 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())),
                     "--dev",
                     "--local",
                 )
@@ -426,13 +423,13 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--local",
                     "--log-level",
                     DEBUG,
@@ -463,14 +460,14 @@ class TestDockerComposeBuilds(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         image_author = "some_author"
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--local",
                     "--log-level",
                     DEBUG,
@@ -506,13 +503,13 @@ class TestKubernetesBuild(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                     "--local",
                 )
@@ -528,13 +525,13 @@ class TestKubernetesBuild(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                     "--local",
                     "--log-level",
@@ -557,13 +554,13 @@ class TestKubernetesBuild(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                     "--dev",
                     "--local",
@@ -586,14 +583,14 @@ class TestKubernetesBuild(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
         keys_file = Path(ETHEREUM_ENCRYPTED_KEYS)
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
 
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                     "--password",
                     ETHEREUM_ENCRYPTION_PASSWORD,
@@ -634,14 +631,14 @@ class TestKubernetesBuild(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
 
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--local",
                     "--kubernetes",
                     "--local-tm-setup",
@@ -666,13 +663,13 @@ class TestKubernetesBuild(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                     "--local",
                     "--log-level",
@@ -696,14 +693,14 @@ class TestKubernetesBuild(BaseDeployBuildTest):
     ) -> None:
         """Run tests."""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         image_author = "some_image_author"
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                     "--local",
                     "--log-level",
@@ -748,13 +745,13 @@ class TestExposePorts(BaseDeployBuildTest):
     def test_expose_agent_ports_docker_compose(self) -> None:
         """Test expose agent ports"""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                 )
             )
 
@@ -778,13 +775,13 @@ class TestExposePorts(BaseDeployBuildTest):
     def test_expose_agent_ports_kubernetes(self) -> None:
         """Test expose agent ports"""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                 )
             )
@@ -829,13 +826,13 @@ class TestExtraVolumes(BaseDeployBuildTest):
     def test_expose_agent_ports_docker_compose(self) -> None:
         """Test expose agent ports"""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                 )
             )
 
@@ -860,13 +857,13 @@ class TestExtraVolumes(BaseDeployBuildTest):
     def test_expose_agent_ports_kubernetes(self) -> None:
         """Test expose agent ports"""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                 )
             )
@@ -917,13 +914,13 @@ class TestLoadEnvVars(BaseDeployBuildTest):
 
     def _run_test(self) -> None:
         """Run test."""
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                 )
             )
 
@@ -982,11 +979,9 @@ class TestResourceSpecification(BaseDeployBuildTest):
     def test_default_resources_docker_compose(self) -> None:
         """Test custom resources"""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
-            result = self.run_cli(
-                (str(self.keys_file), "--o", str(self.t / DEFAULT_BUILD_FOLDER))
-            )
+            result = self.run_cli((str(self.keys_file), "--o", str(build_dir)))
 
         assert result.exit_code == 0, result.output
         assert build_dir.exists()
@@ -1014,13 +1009,13 @@ class TestResourceSpecification(BaseDeployBuildTest):
     def test_default_resources_kuberntes(self) -> None:
         """Test custom resources"""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                 )
             )
@@ -1056,13 +1051,13 @@ class TestResourceSpecification(BaseDeployBuildTest):
     def test_custom_resources_docker_compose(self) -> None:
         """Test custom resources"""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--agent-cpu-limit",
                     "2.0",
                     "--agent-memory-limit",
@@ -1092,13 +1087,13 @@ class TestResourceSpecification(BaseDeployBuildTest):
     def test_custom_resources_kuberntes(self) -> None:
         """Test custom resources"""
 
-        build_dir = self.t / DEFAULT_BUILD_FOLDER
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.run_cli(
                 (
                     str(self.keys_file),
                     "--o",
-                    str(self.t / DEFAULT_BUILD_FOLDER),
+                    str(build_dir),
                     "--kubernetes",
                     "--agent-cpu-request",
                     "1.0",

--- a/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022-2023 Valory AG
+#   Copyright 2024 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -155,6 +155,9 @@ class TestFromToken(BaseChainInteractionTest):
         with mock.patch(
             "autonomy.cli.helpers.deployment.fetch_service_ipfs",
             return_value=service_dir,
+        ), mock.patch(
+            "autonomy.cli.helpers.deployment.build_hash_id",
+            return_value="test",
         ), run_deployment_patch as rdp, (
             build_image_patch
         ), default_remote_registry_patch, default_ipfs_node_patch, ipfs_resolve_patch:
@@ -171,7 +174,7 @@ class TestFromToken(BaseChainInteractionTest):
 
             rdp.assert_not_called()
 
-        assert (self.t / "service" / "abci_build" / "build.yaml").exists()
+        assert (self.t / "service" / "abci_build_test" / "build.yaml").exists()
 
     def test_fail_on_chain_resolve_connection_error(self) -> None:
         """Run test."""

--- a/tests/test_autonomy/test_cli/test_replay/test_agent.py
+++ b/tests/test_autonomy/test_cli/test_replay/test_agent.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022-2023 Valory AG
+#   Copyright 2024 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ from typing import Any, Tuple
 from unittest import mock
 
 from autonomy.cli import cli
+from autonomy.cli.helpers.deployment import build_hash_id
+from autonomy.constants import DEFAULT_BUILD_FOLDER
 from autonomy.deploy.base import TENDERMINT_COM_URL_PARAM, TENDERMINT_URL_PARAM
 from autonomy.replay.agent import AgentRunner
 
@@ -102,6 +104,7 @@ class TestAgentRunner(BaseCliTest):
     def test_run(self) -> None:
         """Test run."""
 
+        build_dir = self.t / DEFAULT_BUILD_FOLDER.format(build_hash_id())
         with mock.patch("os.chown"), OS_ENV_PATCH:
             result = self.cli_runner.invoke(
                 cli,
@@ -111,13 +114,12 @@ class TestAgentRunner(BaseCliTest):
                     str(self.keys_path),
                     "--local",
                     "--o",
-                    str(self.t / "abci_build"),
+                    str(build_dir),
                 ),
             )
 
         assert result.exit_code == 0, result.output
 
-        build_dir = self.t / "abci_build"
         with mock.patch.object(AgentRunner, "start", new=ctrl_c), mock.patch.object(
             AgentRunner, "stop"
         ) as stop_mock, mock.patch(


### PR DESCRIPTION
## Proposed changes

This is done to differentiate docker compose projects, and support running multiple services in parallel.

## Fixes

Closes #2264 
When we do `docker compose up` (happens inside `autonomy deploy run`), docker by default takes `abci_build` as the project name because that's the directory where `docker-compose.yaml` is present. So, any service we start, all of them are grouped by this common name. And when we stop, `docker compose down` stops all the container in this project name (which also included other services).

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [x] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes
- [x] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [ ] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.

