### PR TITLE
Upgrade macos in workflow

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12, windows-latest ]
+        os: [ ubuntu-latest, macos-latest-large, windows-latest ]
         python-version: ["3.10.9"]
 
     timeout-minutes: 18
@@ -196,7 +196,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12, windows-latest ]
+        os: [ ubuntu-latest, macos-latest-large, windows-latest ]
         python-version: [ "3.8", "3.9", "3.10.9", "3.11" ]
 
     timeout-minutes: 90
@@ -269,8 +269,8 @@ jobs:
         run: |
           tox -e packages-py${{ matrix.python-version }}-linux -- -m 'not e2e'
 
-      - if: matrix.os == 'macos-12'
-        name: Install dependencies (macos-12)
+      - if: matrix.os == 'macos-latest-large'
+        name: Install dependencies (macos-latest-large)
         run: |
           pip install tomte[tox]==0.2.17
 
@@ -305,13 +305,13 @@ jobs:
           sudo install skaffold /usr/local/bin/
           skaffold --help
 
-      - if: matrix.os == 'macos-12'
-        name: Framework unit tests macos-12
+      - if: matrix.os == 'macos-latest-large'
+        name: Framework unit tests macos-latest-large
         run: |
           tox -e py${{ matrix.python-version }}-darwin -- -m 'not e2e'
 
-      - if: matrix.os == 'macos-12'
-        name: Packages unit tests macos-12
+      - if: matrix.os == 'macos-latest-large'
+        name: Packages unit tests macos-latest-large
         run: |
           tox -e packages-py${{ matrix.python-version }}-darwin -- -m 'not e2e'
 


### PR DESCRIPTION
The macOS 12 Actions runner image began deprecation on 7/10/24 and will be fully unsupported by 3/12/24 for GitHub and ADO. For more details, see https://github.com/actions/runner-images/issues/10721.

Using macos-latest-large instead of macos-latest, as the latter is ARM-based, while we require AMD architecture (abbbc87c5e9154b7315f70b205d1ee2c15969d66). For more details, see https://github.com/actions/runner-images/issues/9741, and the table in https://github.com/actions/runner-images/blob/ubuntu24/20241117.1/README.md#available-images.