### PR TITLE
Fix the release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-versions }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           sudo apt-get update --fix-missing
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-versions }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           sudo apt-get update --fix-missing

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,9 @@ Packages:
 Chores:
 - Bumps `open-aea@1.62.0` #2297
 
+CI:
+- Fixes the release flow #2298
+
 # 0.18.4 (2025-01-08)
 
 Autonomy:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -7,6 +7,12 @@ Below we describe the additional manual steps required to upgrade between differ
 
 ## `v0.18.4` to `v0.19.0`
 
+- The ledger has introduced a new configuration, called `min_allowed_tip`. 
+  The value is set to 1GWEI. However, this limit only applies for Gnosis.
+  This is not expected to cause important differences in the calculated tip for the rest of the chains,
+  because there is an outlier detection mechanism.
+  However, the best practice would be to override this value to `0` for any chain other than Gnosis.
+  This is planned to be changed in the next `open-aea` version to improve DevX and make this a non-breaking change.
 - The agent now performs an early failure check when attributes for rounds are missing. 
   This check is implemented in the metaclass using a specialized attribute named `extended_requirements`. 
   To customize the attributes being checked for a specific round, 


### PR DESCRIPTION
## Proposed changes

This PR fixes a typo in the release flow that caused the specified Python version to be ignored, resulting in the default version being used instead.

As a result, [failures occurred](https://github.com/valory-xyz/open-autonomy/actions/runs/13055348322/job/36427659469) because the project's Pipfile expects Python 3.10 to be present in the system.

With this fix, the correct Python version will be properly recognized, ensuring the release flow runs as expected.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes
- [ ] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [x] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.

## Further comments

n/a