### PR TITLE
Re-order-build-install

### DIFF
--- a/deployments/Dockerfiles/autonomy/scripts/install.sh
+++ b/deployments/Dockerfiles/autonomy/scripts/install.sh
@@ -12,13 +12,14 @@ echo "Loading $AEA_AGENT"
 aea fetch $AEA_AGENT --alias agent || exit 1
 cd agent
 
+echo "Installing the necessary python dependencies!"
+aea install --timeout 600 $EXTRA_DEPENDENCIES || exit 1
+echo "Successfully Installed the python dependencies."
+
 echo "Building the deployments host dependencies."
 aea build || exit 1
 echo "Successfully built the host dependencies."
 
-echo "Installing the necessary python dependencies!"
-aea install --timeout 600 $EXTRA_DEPENDENCIES || exit 1
-echo "Successfully Installed the python dependencies."
 
 echo "Done."
 cd ..


### PR DESCRIPTION
## Proposed changes

This is quite interesting.

I am trying to use pydantic, as an agent dependency, however the build fails as pydantic is not available as it has not been installed yet.

To replicate;

If you add in pydantic as a dependency a service comprising of this agent will not run.

```
dependencies:
  pydantic: {}
```

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run services that could be impacted and they do not present failures derived from my changes
- [ ] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [ ] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
