### PR TITLE
Fix: Increase aea install timeout limit

### DIFF
--- a/deployments/Dockerfiles/autonomy/scripts/install.sh
+++ b/deployments/Dockerfiles/autonomy/scripts/install.sh
@@ -18,7 +18,7 @@ aea build || exit 1
 echo "Successfully built the host dependencies."
 
 echo "Installing the necessary python dependencies!"
-aea install --timeout 1200 $EXTRA_DEPENDENCIES || exit 1
+aea install --timeout 21600 $EXTRA_DEPENDENCIES || exit 1
 echo "Successfully Installed the python dependencies."
 
 echo "Done."

--- a/tox.ini
+++ b/tox.ini
@@ -955,4 +955,6 @@ sniffio: >=1.3.0
 ; licence is MIT, but the tool does not detect it
 attrs: ==25.3.0
 ; licence is GPL-compatible, but the tool does not detect it
-typing-extensions: ==4.13.0
+typing-extensions: ==4.13.2
+urllib3: >=2.4.0
+; licence is MIT, but the tool does not detect it

--- a/tox.ini
+++ b/tox.ini
@@ -956,5 +956,5 @@ sniffio: >=1.3.0
 attrs: ==25.3.0
 ; licence is GPL-compatible, but the tool does not detect it
 typing-extensions: ==4.13.2
-urllib3: >=2.4.0
 ; licence is MIT, but the tool does not detect it
+urllib3: >=2.4.0


### PR DESCRIPTION
## Proposed changes

The `aea install` command fails with a timeout while building an agent's docker image on `linux/arm/v7` architecture using QEMU emulation. This PR is to fix that.

## Fixes

It increase the timeout.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes
- [ ] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [ ] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
