### PR TITLE
Fix: Run docker deployment with current user

### DIFF
--- a/autonomy/cli/utils/click_utils.py
+++ b/autonomy/cli/utils/click_utils.py
@@ -122,7 +122,9 @@ class NFTArgument(click.ParamType):
 
     METAVAR = "IPFS_HASH_OR_IMAGE_PATH"
 
-    def get_metavar(self, param: click.Parameter) -> str:  # pragma: nocover
+    def get_metavar(
+        self, param: click.Parameter, ctx: click.Context
+    ) -> str:  # pragma: nocover
         """Get metavar"""
         return self.METAVAR
 

--- a/autonomy/data/Dockerfiles/agent/Dockerfile
+++ b/autonomy/data/Dockerfiles/agent/Dockerfile
@@ -15,6 +15,9 @@ WORKDIR /root
 
 RUN AEA_AGENT=${AEA_AGENT} EXTRA_DEPENDENCIES=${EXTRA_DEPENDENCIES} bash /root/scripts/install.sh
 
+RUN chmod -R a+x /root
+RUN chmod -R 777 /home
+
 CMD ["/root/scripts/start.sh"]
 
 HEALTHCHECK --interval=3s --timeout=600s --retries=600 CMD netstat -ltn | grep -c 26658 > /dev/null; if [ 0 != $? ]; then exit 1; fi;

--- a/autonomy/deploy/generators/docker_compose/base.py
+++ b/autonomy/deploy/generators/docker_compose/base.py
@@ -168,6 +168,7 @@ def build_agent_config(  # pylint: disable=too-many-arguments,too-many-locals
         network_address=network_address,
         runtime_image=runtime_image,
         env_file=f"agent_{node_id}.env",
+        user=f"{os.getuid()}:{os.getgid()}",
         network_name=network_name,
         agent_memory_request=resources["agent"]["requested"]["memory"],
         agent_cpu_limit=resources["agent"]["limit"]["cpu"],
@@ -183,7 +184,7 @@ def build_agent_config(  # pylint: disable=too-many-arguments,too-many-locals
     if extra_volumes is not None:
         for host_dir, container_dir in extra_volumes.items():
             config += f"      - {host_dir}:{container_dir}:Z\n"
-            Path(host_dir).resolve().mkdir(exist_ok=True, parents=True)
+            (build_dir / host_dir).resolve().mkdir(exist_ok=True, parents=True)
 
     if agent_ports is not None:
         port_mappings = map(

--- a/autonomy/deploy/generators/docker_compose/templates.py
+++ b/autonomy/deploy/generators/docker_compose/templates.py
@@ -105,6 +105,7 @@ ABCI_NODE_TEMPLATE: str = """
     container_name: {container_name}
     image: {runtime_image}
     env_file: {env_file}
+    user: "{user}"
     networks:
       {network_name}:
         ipv4_address: {network_address}

--- a/deployments/Dockerfiles/autonomy/Dockerfile
+++ b/deployments/Dockerfiles/autonomy/Dockerfile
@@ -11,4 +11,6 @@ RUN curl -sSL https://get.docker.com/ | sh
 
 COPY scripts /root/scripts
 
+RUN chmod -R a+x /root
+
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/deployments/Dockerfiles/autonomy/scripts/install.sh
+++ b/deployments/Dockerfiles/autonomy/scripts/install.sh
@@ -9,6 +9,7 @@ fi
 echo Running the aea with $(aea --version)
 
 echo "Loading $AEA_AGENT"
+cd /home
 aea fetch $AEA_AGENT --alias agent || exit 1
 cd agent
 

--- a/deployments/Dockerfiles/autonomy/scripts/start.sh
+++ b/deployments/Dockerfiles/autonomy/scripts/start.sh
@@ -99,5 +99,5 @@ function main() {
     runAgent
 }
 
-cd agent
+cd /home/agent
 main

--- a/docs/api/cli/utils/click_utils.md
+++ b/docs/api/cli/utils/click_utils.md
@@ -89,7 +89,7 @@ NFT parameter for minting tools.
 #### get`_`metavar
 
 ```python
-def get_metavar(param: click.Parameter) -> str
+def get_metavar(param: click.Parameter, ctx: click.Context) -> str
 ```
 
 Get metavar


### PR DESCRIPTION
## Proposed changes

Make the docker deployment such that the process inside the container running the agent is owned by the current user.

## Fixes

This fixes https://github.com/valory-xyz/olas-operate-middleware/issues/75

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [ ] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run services that could be impacted and they do not present failures derived from my changes
- [x] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [ ] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.

## Further comments

The issue that this PR solves, is the following:
1. An agent runs from docker deployment and has a folder mounted (for example: `data`) to the host system.
2. The agent creates/writes some files in this mounted folder.
3. The agent is stopped (for example through `docker compose down`) gracefully.
4. Now these files created by the agent in this `data` folder are owned by `root` because it was the `root` user running the agent inside the container. Hence, to delete these files, the host will require root privileges.
Ideally, the user running the agent should be able to write on the same files.
