### PR TITLE
Fix: Add aea key to connection also in docker deployment

### DIFF
--- a/deployments/Dockerfiles/autonomy/scripts/start.sh
+++ b/deployments/Dockerfiles/autonomy/scripts/start.sh
@@ -77,6 +77,7 @@ function addKey() {
         echo "$1 key provided. Adding to agent."
         if [[ "$AEA_PASSWORD" != "" ]]; then
             aea add-key $1 --password $AEA_PASSWORD 2>&1 | grep -v "already present!" || true
+            aea add-key $1 --password $AEA_PASSWORD --connection 2>&1 | grep -v "already present!" || true
         else
             aea add-key $1 2>&1 | grep -v "already present!" || true
         fi


### PR DESCRIPTION
## Proposed changes

- [x] Add aea key to connection also when deploying using docker

## Fixes

https://github.com/valory-xyz/quickstart/actions/runs/22304122740/job/64527006740?pr=144#step:10:7148

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run AI agents that could be impacted and they do not present failures derived from my changes
- [x] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [x] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.

## Further comments

N/A
