### PR TITLE
Fix: handle missing skill packages in analyse service command (#2373)

### DIFF
--- a/autonomy/cli/helpers/analyse.py
+++ b/autonomy/cli/helpers/analyse.py
@@ -326,24 +326,29 @@ def _get_chained_abci_skill(
         if override is None:
             continue
 
+        # Check if the skill override has the `is_abstract` property set to true
+        if override.get("is_abstract", False):
+            continue
+
         package_id = PackageId(
             package_type=PackageType.SKILL,
             public_id=skill_id,
         )
 
-        skill_config = cast(
-            SkillConfig,
-            (
-                _load_from_ipfs(package_id=package_id)
-                if is_on_chain_check
-                else _load_from_local(
-                    package_id=package_id, package_manager=package_manager
-                )
-            ),
-        )
-
-        # Check if the skill override has the `is_abstract` property set to true
-        if override.get("is_abstract", False):
+        try:
+            skill_config = cast(
+                SkillConfig,
+                (
+                    _load_from_ipfs(package_id=package_id)
+                    if is_on_chain_check
+                    else _load_from_local(
+                        package_id=package_id, package_manager=package_manager
+                    )
+                ),
+            )
+        except FileNotFoundError:
+            # Skip skills whose packages are not available locally
+            # (e.g. third-party packages that have not been synced)
             continue
 
         # Check if the skill has the `is_abstract` property set to true

--- a/tests/test_autonomy/test_cli/test_analyse/test_verify_service.py
+++ b/tests/test_autonomy/test_cli/test_analyse/test_verify_service.py
@@ -50,6 +50,9 @@ DUMMY_ABCI_CONNECTION_HASH = (
     "bafybeib56ojddzexxbapowofypmpk6zeznqaumwgj7ftneb5ua6sk5k5vo"
 )
 DUMMY_SKILL_HASH = "bafybeib56ojddzexxbapowofypmpk6zeznqaumwgj7ftneb5ua6sk5k5vp"
+DUMMY_NON_ABCI_SKILL_HASH = (
+    "bafybeib56ojddzexxbapowofypmpk6zeznqaumwgj7ftneb5ua6sk5k5vq"
+)
 
 
 def get_dummy_service_config() -> Dict:
@@ -174,6 +177,33 @@ def get_dummy_overrides_abci_connection(env_vars_with_name: bool = False) -> Dic
             "host": "${str:host}",
             "port": "${str:port}",
             "use_tendermint": "${bool:false}",
+        },
+    }
+
+
+def get_dummy_overrides_non_abci_skill(env_vars_with_name: bool = False) -> Dict:
+    """Returns dummy overrides for a non-ABCI skill."""
+    if env_vars_with_name:
+        return {
+            "public_id": "valory/non_abci_skill:0.1.0",
+            "type": "skill",
+            "models": {
+                "params": {
+                    "args": {
+                        "some_param": "${SOME_PARAM:str:default_value}",
+                    },
+                }
+            },
+        }
+    return {
+        "public_id": "valory/non_abci_skill:0.1.0",
+        "type": "skill",
+        "models": {
+            "params": {
+                "args": {
+                    "some_param": "${str:default_value}",
+                },
+            }
         },
     }
 
@@ -436,6 +466,63 @@ class TestVerifySkillConfig(BaseAnalyseServiceTest):
             "The chained ABCI skill `valory/abci_skill:0.1.0` does not contain `params` model"
             in result.stderr
         )
+
+    def test_non_abci_skill_package_not_found(self) -> None:
+        """Test that missing non-ABCI skill packages are skipped gracefully."""
+
+        # Agent config with both ABCI and non-ABCI skills
+        agent_config = get_dummy_agent_config()
+        agent_config["skills"].append(
+            f"valory/non_abci_skill:0.1.0:{DUMMY_NON_ABCI_SKILL_HASH}"
+        )
+
+        non_abci_skill_id = PublicId.from_str(
+            f"valory/non_abci_skill:0.1.0:{DUMMY_NON_ABCI_SKILL_HASH}"
+        )
+
+        def _loader_patch(package_id: PackageId, **kwargs: Any) -> Any:
+            if package_id.package_type == PackageType.SERVICE:
+                service_data = [
+                    get_dummy_service_config(),
+                    get_dummy_overrides_skill(env_vars_with_name=True),
+                    get_dummy_overrides_non_abci_skill(env_vars_with_name=True),
+                ]
+                config, *overrides = service_data
+                service = Service.from_json(config)
+                service.overrides = overrides
+                return service
+
+            if package_id.package_type == PackageType.AGENT:
+                agent_data = [
+                    agent_config,
+                    get_dummy_overrides_skill(),
+                    get_dummy_overrides_non_abci_skill(),
+                ]
+                config, *_overrides = agent_data
+                agent_cfg = AgentConfig.from_json(config)
+                processed_overrides = {}
+                for o in _overrides:
+                    processed_overrides[
+                        ComponentId(
+                            component_type=ComponentType(o.pop("type")),
+                            public_id=PublicId.from_str(o.pop("public_id")),
+                        )
+                    ] = o
+                agent_cfg.component_configurations = processed_overrides
+                return agent_cfg
+
+            if package_id.package_type == PackageType.SKILL:
+                if package_id.public_id.to_any() == non_abci_skill_id.to_any():
+                    raise FileNotFoundError("Package not found")
+                return SkillConfig.from_json(get_dummy_skill_config())
+
+        with mock.patch(
+            "autonomy.cli.helpers.analyse._load_from_local",
+            new=_loader_patch,
+        ), self.patch_ipfs_tool([]):
+            result = self.run_cli(commands=self.public_id_option)
+
+        assert result.exit_code == 0, result.stderr
 
 
 class TestCheckRequiredAgentOverrides(BaseAnalyseServiceTest):


### PR DESCRIPTION
Skip skills whose packages are not available locally (e.g. third-party packages that have not been synced) instead of crashing with FileNotFoundError. Also move the is_abstract override check before loading the skill package to avoid unnecessary loads.

## Proposed changes

 Summary                                                                                                                                         
                                                                                                                                                  
  - Fixes _get_chained_abci_skill to gracefully skip skills whose packages are not available locally (e.g. third-party packages that have not been
   synced) instead of crashing with FileNotFoundError                                                                                             
  - Moves the is_abstract override check before loading the skill package to avoid unnecessary loads                                              
  - Adds test for the new behavior with a non-ABCI skill whose package is missing                                                                 

  Test plan

  - All 21 verify_service tests pass (20 existing + 1 new)
  - Verify tox -e analyse-service works in downstream repos (trader, mech) with third-party skill dependencies

Fixes #2373

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run AI agents that could be impacted and they do not present failures derived from my changes
- [x] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [x] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.

## Further comments

-