### PR TITLE
Fix: user images fail to build on ubuntu-latest (#2312)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,18 +87,17 @@ jobs:
     needs:
       - publish-autonomy-packages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
         run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-      - name: Set up support for multi platform build
-        run: |
-          docker run --privileged --rm tonistiigi/binfmt --install all
-          docker buildx create --use --name multibuild
-          docker buildx inspect --bootstrap
       - name: Set up tag
         run: echo export TAG=$(python3 -c "from setup import about; print(about[\"__version__\"])") > env.sh
       - name: Build and push version tagged images
@@ -110,22 +109,21 @@ jobs:
 
   publish-user-images:
     name: Publish User Images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs:
       - publish-autonomy-packages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
         run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-      - name: Set up support for multi platform build
-        run: |
-          docker run --privileged --rm tonistiigi/binfmt --install all
-          docker buildx create --use --name multibuild
-          docker buildx inspect --bootstrap
       - name: Set up tag
         run: echo export TAG=$(python3 -c "from setup import about; print(about[\"__version__\"])") > env.sh
       - name: Build and push version tagged images
@@ -141,18 +139,17 @@ jobs:
     needs:
       - publish-autonomy-packages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker login
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
         run: |
           docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
-      - name: Set up support for multi platform build
-        run: |
-          docker run --privileged --rm tonistiigi/binfmt --install all
-          docker buildx create --use --name multibuild
-          docker buildx inspect --bootstrap
       - name: Set up tag
         run: echo export TAG=$(python3 -c "from setup import about; print(about[\"__version__\"])") > env.sh
       - name: Build and push version tagged images

--- a/deployments/Dockerfiles/autonomy-user/Dockerfile
+++ b/deployments/Dockerfiles/autonomy-user/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM python:3.14-slim-bullseye AS base
+FROM python:3.14-slim-bookworm AS base
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
@@ -12,7 +12,7 @@ RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 # Customize base image with agent deps
-FROM python:3.14-slim-bullseye AS agent_deps
+FROM python:3.14-slim-bookworm AS agent_deps
 ARG AUTHOR=user
 
 # Install docker

--- a/deployments/Dockerfiles/autonomy-user/requirements.txt
+++ b/deployments/Dockerfiles/autonomy-user/requirements.txt
@@ -2,4 +2,4 @@ open-autonomy[all]==0.21.11
 open-aea[all]==2.1.0rc4
 open-aea-cli-ipfs==2.1.0rc4
 open-aea-ledger-ethereum==2.1.0rc4
-protobuf>=4.21.6,<5.0.0
+protobuf>=5,<6


### PR DESCRIPTION
## Proposed changes

  Summary                                                                                                                                         
                                                                                                                                                  
  - Update autonomy-user Dockerfile base from bullseye (Debian 11) to bookworm (Debian 12)                                                        
  - Update protobuf constraint in requirements.txt from >=4.21.6,<5.0.0 to >=5,<6 to match the project                                            
  - Replace manual tonistiigi/binfmt + docker buildx create setup with official docker/setup-qemu-action@v3 and docker/setup-buildx-action@v3
  across all three publish jobs
  - Update actions/checkout from v2 to v4                                                                                                         
  - Revert ubuntu-22.04 workaround back to ubuntu-latest                                                                                          
                                                                                                                                                  
  Test plan

  - Verify the release workflow builds and pushes user images successfully on ubuntu-latest

Fixes #2312

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have locally run AI agents that could be impacted and they do not present failures derived from my changes
- [x] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [x] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.

## Further comments

-