### PR TITLE
fix(release): unblock Python 3.14 packaging flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Build wheels and source tarball
         run: |
           echo Processing open-autonomy
+          pipenv run pip install --upgrade setuptools wheel
           pipenv run make dist
 
           echo Processing aea-test-autonomy
@@ -100,7 +101,7 @@ jobs:
           docker buildx create --use --name multibuild
           docker buildx inspect --bootstrap
       - name: Set up tag
-        run: echo export TAG=$(python3 -c "from setup import about; print(about[\"__version__\"])") > env.sh
+        run: echo export TAG=$(python3 -c "import runpy; print(runpy.run_path('autonomy/__version__.py')['__version__'])") > env.sh
       - name: Build and push version tagged images
         run: |
           # export `TAG` variable
@@ -127,7 +128,7 @@ jobs:
           docker buildx create --use --name multibuild
           docker buildx inspect --bootstrap
       - name: Set up tag
-        run: echo export TAG=$(python3 -c "from setup import about; print(about[\"__version__\"])") > env.sh
+        run: echo export TAG=$(python3 -c "import runpy; print(runpy.run_path('autonomy/__version__.py')['__version__'])") > env.sh
       - name: Build and push version tagged images
         run: |
           # export `TAG` variable
@@ -154,7 +155,7 @@ jobs:
           docker buildx create --use --name multibuild
           docker buildx inspect --bootstrap
       - name: Set up tag
-        run: echo export TAG=$(python3 -c "from setup import about; print(about[\"__version__\"])") > env.sh
+        run: echo export TAG=$(python3 -c "import runpy; print(runpy.run_path('autonomy/__version__.py')['__version__'])") > env.sh
       - name: Build and push version tagged images
         run: |
           # export `TAG` variable
@@ -185,7 +186,7 @@ jobs:
           docker buildx create --use --name multibuild
           docker buildx inspect --bootstrap
       - name: Set up tag
-        run: echo export TAG=$(python3 -c "from setup import about; print(about[\"__version__\"])") > env.sh
+        run: echo export TAG=$(python3 -c "import runpy; print(runpy.run_path('autonomy/__version__.py')['__version__'])") > env.sh
       - name: Build and push version tagged images
         run: |
           # export `TAG` variable

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,6 @@ import os
 import re
 from typing import Dict
 
-from setuptools import find_packages, setup  # type: ignore
-
 
 PACKAGE_NAME = "autonomy"
 here = os.path.abspath(os.path.dirname(__file__))
@@ -88,6 +86,8 @@ def parse_readme():
 
 
 if __name__ == "__main__":
+    from setuptools import find_packages, setup
+
     setup(
         name=about["__title__"],
         description=about["__description__"],


### PR DESCRIPTION
## Summary
Fix release workflow failures after moving CI to Python 3.14 where setuptools is not implicitly available in all execution paths.

## Root cause
- Release packaging failed during `pipenv run make dist` with `ModuleNotFoundError: No module named 'setuptools'`.
- Image publish jobs imported `setup.py` just to read `__version__`, introducing an unnecessary setuptools dependency at import time.

## Changes
- `.github/workflows/release.yml`
  - Install build tools inside pipenv before building distributions:
    - `pipenv run pip install --upgrade setuptools wheel`
  - Replace `from setup import about` tag extraction with direct version read from `autonomy/__version__.py` via `runpy.run_path(...)`.
- `setup.py`
  - Move `setuptools` import into the `if __name__ == "__main__":` block so metadata import paths do not fail when setuptools is missing.

## Verification
Validated locally with Python 3.14.3 in a clean environment:
- `make dist` succeeds
- `plugins/aea-test-autonomy/setup.py sdist bdist_wheel` succeeds
- version extraction via `runpy.run_path('autonomy/__version__.py')` succeeds

## Impact
- Fixes release workflow breakage on Python 3.14
- Preserves package build behavior while making non-build metadata paths resilient