### PR TITLE
fix(release): install local source in package-publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get autoremove
           sudo apt-get autoclean
           python -m pip install --upgrade pip
-          pip install open-autonomy[all] --no-cache
+          pip install .[all] --no-cache
 
       - name: Push Packages
         run: |


### PR DESCRIPTION
## Summary
Fix release workflow failure in `publish-autonomy-packages` by installing `open-autonomy` from the checked-out source instead of pulling from PyPI.

## Root cause
The job used:
- `pip install open-autonomy[all] --no-cache`

On Python 3.14 this fetched an older published package version from PyPI, which pulled incompatible dependency versions and failed during `autonomy init`.

## Change
In `.github/workflows/release.yml`:
- Replaced `pip install open-autonomy[all] --no-cache`
- With `pip install .[all] --no-cache`

## Why this works
Installing from the checked-out release source guarantees the current tagged code and dependency pins are used in the same workflow run, avoiding PyPI propagation/version race issues.

## Validation
Locally verified on Python 3.14.3:
- `pip install '.[all]' --no-cache` succeeds
- `autonomy --version` succeeds and reports current release version