### PR TITLE
fix: update defaults for click commands  options

### DIFF
--- a/autonomy/cli/deploy.py
+++ b/autonomy/cli/deploy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022-2025 Valory AG
+#   Copyright 2022-2026 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -137,19 +137,21 @@ def deploy_group(
     "--localhost",
     "deployment_type",
     flag_value=HostDeploymentGenerator.deployment_type,
+    default=DockerComposeGenerator.deployment_type,
     help="Use localhost as a backend.",
 )
 @click.option(
     "--docker",
     "deployment_type",
     flag_value=DockerComposeGenerator.deployment_type,
-    default=True,
+    default=DockerComposeGenerator.deployment_type,
     help="Use docker as a backend. (default)",
 )
 @click.option(
     "--kubernetes",
     "deployment_type",
     flag_value=KubernetesGenerator.deployment_type,
+    default=DockerComposeGenerator.deployment_type,
     help="Use kubernetes as a backend.",
 )
 @click.option(
@@ -319,7 +321,7 @@ def build_deployment_command(  # pylint: disable=too-many-locals
                 },
             )
         except (NotValidKeysFile, FileNotFoundError, FileExistsError) as e:
-            shutil.rmtree(build_dir)
+            shutil.rmtree(build_dir, ignore_errors=True)
             raise click.ClickException(str(e)) from e
 
 
@@ -351,6 +353,7 @@ def build_deployment_command(  # pylint: disable=too-many-locals
     "--localhost",
     "deployment_type",
     flag_value="localhost",
+    default="docker",
     help="Use localhost as a backend.",
 )
 @click.option(
@@ -358,7 +361,7 @@ def build_deployment_command(  # pylint: disable=too-many-locals
     "deployment_type",
     flag_value="docker",
     help="Use docker as a backend. (default)",
-    default=True,
+    default="docker",
 )
 def run(
     build_dir: Path,
@@ -416,13 +419,14 @@ def stop(build_dir: Path) -> None:
     "--docker",
     "deployment_type",
     flag_value=DockerComposeGenerator.deployment_type,
-    default=True,
+    default=DockerComposeGenerator.deployment_type,
     help="Use docker as a backend.",
 )
 @click.option(
     "--kubernetes",
     "deployment_type",
     flag_value=KubernetesGenerator.deployment_type,
+    default=DockerComposeGenerator.deployment_type,
     help="Use kubernetes as a backend.",
 )
 @click.option(

--- a/autonomy/cli/fetch.py
+++ b/autonomy/cli/fetch.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022-2024 Valory AG
+#   Copyright 2022-2026 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -45,13 +45,14 @@ from autonomy.cli.utils.click_utils import PublicIdOrHashOrTokenId, chain_select
     "--agent",
     "package_type",
     help="Specify the package type as agent (default).",
-    default=True,
+    default=AGENT,
     flag_value=AGENT,
 )
 @click.option(
     "--service",
     "package_type",
     help="Specify the package type as service.",
+    default=AGENT,
     flag_value=SERVICE,
 )
 @click.argument("public-id", type=PublicIdOrHashOrTokenId(), required=True)

--- a/autonomy/cli/utils/click_utils.py
+++ b/autonomy/cli/utils/click_utils.py
@@ -42,13 +42,14 @@ def image_profile_flag(
     """Choice of one flag between: '--local/--remote'."""
 
     def wrapper(f: Callable) -> Callable:
+        option_default = default if mark_default else None
         for profile in ImageProfiles.ALL:
             f = click.option(
                 f"--{profile}",
                 "profile",
                 flag_value=profile,
                 help=f"To use the {profile} profile.",
-                default=(profile == default) and mark_default,
+                default=option_default,
             )(f)
 
         return f
@@ -62,14 +63,13 @@ def abci_spec_format_flag(
     """Flags for abci spec outputs formats."""
 
     def wrapper(f: Callable) -> Callable:
+        option_default = default if mark_default else None
         for of in FSMSpecificationLoader.OutputFormats.ALL:
-            is_default = (of == default) and mark_default
             option_kwargs: Dict[str, Any] = dict(
                 flag_value=of,
                 help=f"{of.title()} file.",
+                default=option_default,
             )
-            if is_default:
-                option_kwargs["default"] = of
             f = click.option(
                 f"--{of}",
                 "spec_format",
@@ -89,15 +89,14 @@ def chain_selection_flag(
     """Flags for abci spec outputs formats."""
 
     def wrapper(f: Callable) -> Callable:
+        option_default = default.value if mark_default else None
         for chain_type in ChainType:
             chain_name = cast(str, chain_type.value).replace("_", "-")
-            is_default = (chain_type == default) and mark_default
             option_kwargs: Dict[str, Any] = dict(
                 flag_value=chain_type.value,
                 help=help_string_format.format(chain_name),
+                default=option_default,
             )
-            if is_default:
-                option_kwargs["default"] = chain_type.value
             f = click.option(
                 f"--use-{chain_name}",
                 "chain_type",

--- a/docs/api/cli/deploy.md
+++ b/docs/api/cli/deploy.md
@@ -57,19 +57,21 @@ Deploy an agent service.
     "--localhost",
     "deployment_type",
     flag_value=HostDeploymentGenerator.deployment_type,
+    default=DockerComposeGenerator.deployment_type,
     help="Use localhost as a backend.",
 )
 @click.option(
     "--docker",
     "deployment_type",
     flag_value=DockerComposeGenerator.deployment_type,
-    default=True,
+    default=DockerComposeGenerator.deployment_type,
     help="Use docker as a backend. (default)",
 )
 @click.option(
     "--kubernetes",
     "deployment_type",
     flag_value=KubernetesGenerator.deployment_type,
+    default=DockerComposeGenerator.deployment_type,
     help="Use kubernetes as a backend.",
 )
 @click.option(
@@ -218,6 +220,7 @@ Build deployment setup for n agents.
     "--localhost",
     "deployment_type",
     flag_value="localhost",
+    default="docker",
     help="Use localhost as a backend.",
 )
 @click.option(
@@ -225,7 +228,7 @@ Build deployment setup for n agents.
     "deployment_type",
     flag_value="docker",
     help="Use docker as a backend. (default)",
-    default=True,
+    default="docker",
 )
 def run(build_dir: Path, no_recreate: bool, remove_orphans: bool, detach: bool,
         deployment_type: str) -> None
@@ -274,13 +277,14 @@ Stop a running deployment.
     "--docker",
     "deployment_type",
     flag_value=DockerComposeGenerator.deployment_type,
-    default=True,
+    default=DockerComposeGenerator.deployment_type,
     help="Use docker as a backend.",
 )
 @click.option(
     "--kubernetes",
     "deployment_type",
     flag_value=KubernetesGenerator.deployment_type,
+    default=DockerComposeGenerator.deployment_type,
     help="Use kubernetes as a backend.",
 )
 @click.option(

--- a/docs/api/cli/fetch.md
+++ b/docs/api/cli/fetch.md
@@ -21,13 +21,14 @@ Implementation of the 'autonomy fetch' subcommand.
     "--agent",
     "package_type",
     help="Specify the package type as agent (default).",
-    default=True,
+    default=AGENT,
     flag_value=AGENT,
 )
 @click.option(
     "--service",
     "package_type",
     help="Specify the package type as service.",
+    default=AGENT,
     flag_value=SERVICE,
 )
 @click.argument("public-id", type=PublicIdOrHashOrTokenId(), required=True)

--- a/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_from_token.py
@@ -24,11 +24,13 @@ import os
 from pathlib import Path
 from unittest import mock
 
+import click
 import pytest
 from aea.cli.registry.settings import REMOTE_IPFS
 from aea_test_autonomy.fixture_helpers import registries_scope_class  # noqa: F401
 
 from autonomy.chain.exceptions import FailedToRetrieveComponentMetadata
+from autonomy.cli.deploy import run_deployment_from_token
 
 from tests.conftest import ROOT_DIR, skip_docker_tests
 from tests.test_autonomy.test_chain.base import BaseChainInteractionTest
@@ -73,6 +75,23 @@ ipfs_resolve_patch = mock.patch(
     "autonomy.cli.helpers.deployment.resolve_component_id",
     return_value=MOCK_IPFS_RESPONSE,
 )
+
+
+def test_from_token_deployment_type_defaults() -> None:
+    """Test from-token deployment type defaults are order-robust."""
+
+    deployment_type_options = [
+        parameter
+        for parameter in run_deployment_from_token.params
+        if isinstance(parameter, click.Option) and parameter.name == "deployment_type"
+    ]
+
+    assert len(deployment_type_options) == 2
+    default_values = {option.default for option in deployment_type_options}
+    assert len(default_values) == 1
+    default_value = default_values.pop()
+    assert isinstance(default_value, str)
+    assert default_value in {option.flag_value for option in deployment_type_options}
 
 
 @pytest.mark.integration

--- a/tests/test_autonomy/test_cli/test_deploy/test_run_deployment.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_run_deployment.py
@@ -24,8 +24,11 @@ import os
 import shutil
 from unittest import mock
 
+import click
 from aea.configurations.constants import DEFAULT_AEA_CONFIG_FILE, PACKAGES
 
+from autonomy.cli.deploy import build_deployment_command
+from autonomy.cli.deploy import run as run_cmd
 from autonomy.constants import DEFAULT_BUILD_FOLDER, DOCKER_COMPOSE_YAML, VALORY
 from autonomy.deploy.base import ServiceBuilder
 from autonomy.deploy.constants import (
@@ -38,6 +41,40 @@ from tests.test_autonomy.test_cli.base import BaseCliTest
 from tests.test_autonomy.test_cli.test_deploy.test_build.test_deployment import (
     OS_ENV_PATCH,
 )
+
+
+def test_run_deployment_type_defaults() -> None:
+    """Test run command deployment type defaults are order-robust."""
+
+    deployment_type_options = [
+        parameter
+        for parameter in run_cmd.params
+        if isinstance(parameter, click.Option) and parameter.name == "deployment_type"
+    ]
+
+    assert len(deployment_type_options) == 2
+    default_values = {option.default for option in deployment_type_options}
+    assert len(default_values) == 1
+    default_value = default_values.pop()
+    assert isinstance(default_value, str)
+    assert default_value in {option.flag_value for option in deployment_type_options}
+
+
+def test_build_deployment_type_defaults() -> None:
+    """Test build command deployment type defaults are order-robust."""
+
+    deployment_type_options = [
+        parameter
+        for parameter in build_deployment_command.params
+        if isinstance(parameter, click.Option) and parameter.name == "deployment_type"
+    ]
+
+    assert len(deployment_type_options) == 3
+    default_values = {option.default for option in deployment_type_options}
+    assert len(default_values) == 1
+    default_value = default_values.pop()
+    assert isinstance(default_value, str)
+    assert default_value in {option.flag_value for option in deployment_type_options}
 
 
 class TestRun(BaseCliTest):

--- a/tests/test_autonomy/test_cli/test_fetch.py
+++ b/tests/test_autonomy/test_cli/test_fetch.py
@@ -24,10 +24,12 @@ import shutil
 from pathlib import Path
 from unittest import mock
 
+import click
 import pytest
 from aea.cli.fetch import NotAnAgentPackage
 from aea.cli.registry.settings import REMOTE_IPFS
 from aea.configurations.constants import (
+    AGENT,
     DEFAULT_README_FILE,
     DEFAULT_SERVICE_CONFIG_FILE,
 )
@@ -37,6 +39,7 @@ from aea.helpers.io import open_file
 from aea_test_autonomy.fixture_helpers import registries_scope_class  # noqa: F401
 
 from autonomy.chain.exceptions import FailedToRetrieveComponentMetadata
+from autonomy.cli.fetch import fetch as fetch_cmd
 from autonomy.cli.helpers.registry import IPFSTool
 from autonomy.configurations.base import Service
 
@@ -46,6 +49,19 @@ from tests.test_autonomy.test_chain.base import BaseChainInteractionTest
 from tests.test_autonomy.test_cli.base import BaseCliTest, cli
 
 IPFS_REGISTRY = "/dns/registry.autonolas.tech/tcp/443/https"
+
+
+def test_fetch_package_type_defaults() -> None:
+    """Test fetch package type defaults are order-robust."""
+
+    package_type_options = [
+        parameter
+        for parameter in fetch_cmd.params
+        if isinstance(parameter, click.Option) and parameter.name == "package_type"
+    ]
+
+    assert len(package_type_options) == 2
+    assert all(option.default == AGENT for option in package_type_options)
 
 
 class FetchTest(BaseCliTest):

--- a/tests/test_autonomy/test_cli/test_utils/test_click_utils.py
+++ b/tests/test_autonomy/test_cli/test_utils/test_click_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022-2023 Valory AG
+#   Copyright 2022-2026 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -52,18 +52,28 @@ class ClickFlagTestCase:
     decorator: Callable
     items: Tuple
     opt_prefix: str = ""
+    expected_default: Optional[str] = None
 
 
 @pytest.mark.parametrize(
     "test_case",
     [
-        ClickFlagTestCase(image_profile_flag, ImageProfiles.ALL),
+        ClickFlagTestCase(
+            image_profile_flag,
+            ImageProfiles.ALL,
+            expected_default=ImageProfiles.PRODUCTION,
+        ),
         ClickFlagTestCase(
             chain_selection_flag,
             tuple(map(lambda x: x.value, ChainType)),
             opt_prefix="use-",
+            expected_default=ChainType.LOCAL.value,
         ),
-        ClickFlagTestCase(abci_spec_format_flag, FSMSpecLoader.OutputFormats.ALL),
+        ClickFlagTestCase(
+            abci_spec_format_flag,
+            FSMSpecLoader.OutputFormats.ALL,
+            expected_default=FSMSpecLoader.OutputFormats.YAML,
+        ),
     ],
 )
 def test_flag_decorators(test_case: ClickFlagTestCase) -> None:
@@ -80,6 +90,7 @@ def test_flag_decorators(test_case: ClickFlagTestCase) -> None:
         assert item in parameter.flag_value
         assert parameter.opts == [f"--{test_case.opt_prefix}" + item.replace("_", "-")]
         assert parameter.help
+        assert parameter.default == test_case.expected_default
 
 
 def test_path_argument() -> None:


### PR DESCRIPTION
**Title**
Fix Click flag_value defaults to be order-robust across deploy/fetch CLI flags

**Summary**
- Replaces boolean/per-option defaults with stable shared string defaults for grouped options targeting the same parameter.
- Prevents incorrect default resolution caused by Click option-processing order.

**What changed**
- Updated deployment-type flag groups in deploy.py:
  - build command backend flags
  - run command backend flags
  - from-token command backend flags
- Updated fetch package-type flags in fetch.py so default resolves consistently to agent.
- Hardened shared decorators in click_utils.py:
  - image_profile_flag

**Tests**
- Added regression checks for default consistency in:
  - test_click_utils.py
  - test_fetch.py
  - test_run_deployment.py
  - test_from_token.py
- Targeted test run result: 15 passed, 0 failed.

**Why this is needed**
- Aligns open-autonomy behavior with Click default handling breaking change.
- Ensures deterministic CLI defaults regardless of decorator/option ordering.
- Reduces risk of subtle runtime misconfiguration in deploy/fetch flows.