### PR TITLE
Fix TestSlashing flaky rerun: comprehensive state reset in setup/tear…

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -54,7 +54,7 @@
         "agent/valory/registration_start_up/0.1.0": "bafybeicoc4xoh2dxutpoxpa4eemsn5x7ygzyawgk7czk3edqzjtlbl7y4y",
         "agent/valory/test_abci/0.1.0": "bafybeicl723sqcm3ctoza2vwmnzu7ffkqdrxhu3bxhwdlwyvftmvonbn3q",
         "agent/valory/register_reset_recovery/0.1.0": "bafybeifpe26d7ms5zitao27tjhy3mnzhwbjoldq7aau47jbtf2gardfnhm",
-        "agent/valory/offend_slash/0.1.0": "bafybeianmgiuexltgyk6zoapg235shbaxiesquz7fr5nrnforzuylefosq",
+        "agent/valory/offend_slash/0.1.0": "bafybeiamhxjz7jykp3aml7un4cnoqfamttrebg5d32uwvownipoeepho6u",
         "agent/valory/solana_transfer_agent/0.1.0": "bafybeicap4liqaoz6v7vmuejiwxposllbzcjbfg2apvzojaiq3uxlye6wi",
         "service/valory/counter/0.1.0": "bafybeiba6bbmpsjpqdkompap4x2kwg4nikkvnvmz7rqct6r5geg5bvbcam",
         "service/valory/register_reset/0.1.0": "bafybeidiyfehyjtupyjyhysy3vd4p6hdga6oiseqhxitzhjjjprf2zydpm"

--- a/packages/valory/agents/offend_slash/aea-config.yaml
+++ b/packages/valory/agents/offend_slash/aea-config.yaml
@@ -8,7 +8,7 @@ fingerprint:
   README.md: bafybeiasjwf6kbarer3lyrgik3kravnh35cs743xeun2n5pqssdf5hjzda
   __init__.py: bafybeihpqeerwvdztwaovdaas3lecjxztp7yectgjsqbk4phmpdjnww6fi
   tests/__init__.py: bafybeic5zltt6wlvoegj2tfewe6qgr5f743lef4d6bkgvlqyfsnleiyb6y
-  tests/test_offend_slash.py: bafybeichna4qvunvfnkdwt2v4ngjixka3mjync6xdhbxreeq2jhucjkm2y
+  tests/test_offend_slash.py: bafybeic62qhx2glxfv3itse7ykc5eybmvdubdqs5pdcnfhc7j6axnvpwfe
 fingerprint_ignore_patterns: []
 connections:
 - valory/abci:0.1.0:bafybeicebncf2ahrqpyqzkzriigp3ibfqhyxn74jqmwkllvns5rckgyyri

--- a/packages/valory/agents/offend_slash/tests/test_offend_slash.py
+++ b/packages/valory/agents/offend_slash/tests/test_offend_slash.py
@@ -19,6 +19,10 @@
 
 """e2e tests for the `valory/offend_slash` skill."""
 
+import logging
+import os
+import shutil
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -84,6 +88,32 @@ class SlashingE2E(
     skill_package = "valory/offend_slash_abci:0.1.0"
     wait_to_finish = 200
     _args_prefix = f"vendor.valory.skills.{PublicId.from_str(skill_package).name}.models.params.args"
+    _run_count: int = 0
+
+    def setup_method(self) -> None:
+        """Reinitialize temp directory on flaky reruns."""
+        type(self)._run_count += 1
+        if self._run_count <= 1:
+            return
+        logging.info("Flaky rerun detected, reinitializing temp directory")
+        type(self).t = Path(tempfile.mkdtemp())
+        os.chdir(self.t)
+        registry_tmp_dir = self.t / self.packages_dir_path
+        shutil.copytree(str(self.package_registry_src), str(registry_tmp_dir))
+        self.initialize_aea(self.author)
+        type(self).subprocesses = []
+        type(self).threads = []
+        type(self).agents = set()
+        type(self).current_agent_context = ""
+        type(self).stdout = {}
+        type(self).stderr = {}
+
+    def teardown_method(self) -> None:
+        """Clean up temp directory so flaky reruns start fresh."""
+        self.terminate_agents()
+        self._join_threads()
+        os.chdir(self.old_cwd)
+        shutil.rmtree(self.t, ignore_errors=True)
 
     def __set_configs(  # pylint: disable=unused-private-member
         self, i: int, nb_agents: int


### PR DESCRIPTION
…down

Cherry-picked from feat/python3.14-compat (89952164a). On flaky reruns, setup_class is not re-invoked, so stale state from the first failed attempt caused "agent_00000 already exists" errors. Add setup_method/ teardown_method to SlashingE2E that properly terminates agents, joins threads, and resets all class-level state using type(self).

## Proposed changes

-

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [x] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [ ] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have locally run AI agents that could be impacted and they do not present failures derived from my changes
- [ ] Public-facing documentation has been updated with the changes affected by this PR. Even if the provided contents are not in their final form, all significant information must be included.
- [ ] Any backwards-incompatible/breaking change has been clearly documented in the upgrading document.

## Further comments

-