### PR TITLE
docs: scripts consolidation report — open-aea & open-autonomy

### DIFF
--- a/SCRIPTS_CONSOLIDATION_IMPLEMENTATION_PLAN.md
+++ b/SCRIPTS_CONSOLIDATION_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,241 @@
+# Scripts Consolidation — Implementation Plan
+
+Phased rollout plan for the changes described in `SCRIPTS_CONSOLIDATION_REPORT.md`.
+
+---
+
+## Phase 0: Preparation
+
+**Scope:** No code changes. Alignment and setup.
+
+- [ ] Get sign-off on SCRIPTS_CONSOLIDATION_REPORT.md from team
+- [ ] Decide on version numbers for new/renamed packages
+- [ ] Verify tomte's `check-copyright`, `check-doc-links`, `freeze-dependencies` produce identical output to the local scripts (smoke test)
+
+**Duration:** 1 day
+
+---
+
+## Phase 1: tomte
+
+**Scope:** Ensure tomte covers all the scripts we want to delegate to it. If any gaps exist (different CLI flags, missing features), fix them in tomte first.
+
+**Repo:** `valory-xyz/tomte`
+
+### Tasks
+
+- [ ] Compare `tomte check-copyright` vs `open-aea/scripts/check_copyright_notice.py` — verify feature parity (author detection, year updating, exclude patterns)
+- [ ] Compare `tomte check-doc-links` vs `open-aea/scripts/check_doc_links.py` — verify feature parity (retry logic, skip patterns, timeout handling)
+- [ ] Compare `tomte freeze-dependencies` vs `open-aea/scripts/freeze_dependencies.py` — verify feature parity
+- [ ] Compare `tomte check-spelling` vs `open-aea/scripts/spell-check.sh` — verify feature parity
+- [ ] If any gaps: submit PRs to tomte, get them released
+- [ ] Release new tomte version if needed (e.g., `0.6.3`)
+
+**Duration:** 1 day (if no gaps) / 2-3 days (if gaps need fixing)
+
+---
+
+## Phase 2: open-aea
+
+**Scope:** Create the new `open-aea-ci-helpers` plugin. Switch open-aea's own `tox.ini` to use tomte + aea-ci instead of local scripts. Delete migrated/obsolete scripts.
+
+**Repo:** `valory-xyz/open-aea`
+
+### Step 2a: Create `open-aea-ci-helpers` plugin
+
+- [ ] Create `plugins/aea-ci-helpers/` directory structure
+- [ ] Create `setup.py` with PyPI name `open-aea-ci-helpers`
+- [ ] Migrate scripts as Click subcommands:
+  - [ ] `aea-ci check-ipfs-pushed` (from `scripts/check_ipfs_hashes_pushed.py`)
+  - [ ] `aea-ci check-imports` (from `scripts/check_imports_and_dependencies.py`)
+  - [ ] `aea-ci check-pyproject` (from `scripts/check_pyproject_and_toxini.py`)
+  - [ ] `aea-ci check-pkg-versions` (from `scripts/check_package_versions_in_docs.py`)
+  - [ ] `aea-ci generate-api-docs` (from `scripts/generate_api_docs.py`)
+  - [ ] `aea-ci generate-pkg-list` (from `scripts/generate_package_list.py`)
+- [ ] Add tests for new commands
+- [ ] Verify all linters pass
+
+### Step 2b: Switch open-aea's tox.ini
+
+- [ ] Update tox environments to install `open-aea-ci-helpers` (from local `plugins/aea-ci-helpers`)
+- [ ] Replace `scripts/check_copyright_notice.py` invocations with `tomte check-copyright`
+- [ ] Replace `scripts/check_doc_links.py` invocations with `tomte check-doc-links`
+- [ ] Replace `scripts/freeze_dependencies.py` invocations with `tomte freeze-dependencies`
+- [ ] Replace `scripts/check_ipfs_hashes_pushed.py` invocations with `aea-ci check-ipfs-pushed`
+- [ ] Replace `scripts/check_imports_and_dependencies.py` invocations with `aea-ci check-imports`
+- [ ] Replace remaining script invocations with corresponding `aea-ci` commands
+- [ ] Verify CI passes
+
+### Step 2c: Delete migrated/obsolete scripts
+
+- [ ] Delete `scripts/check_copyright_notice.py` (-> tomte)
+- [ ] Delete `scripts/check_doc_links.py` (-> tomte)
+- [ ] Delete `scripts/freeze_dependencies.py` (-> tomte)
+- [ ] Delete `scripts/check_ipfs_hashes_pushed.py` (-> aea-ci)
+- [ ] Delete `scripts/check_imports_and_dependencies.py` (-> aea-ci)
+- [ ] Delete `scripts/check_pyproject_and_toxini.py` (-> aea-ci)
+- [ ] Delete `scripts/check_package_versions_in_docs.py` (-> aea-ci)
+- [ ] Delete `scripts/generate_api_docs.py` (-> aea-ci)
+- [ ] Delete `scripts/generate_package_list.py` (-> aea-ci)
+- [ ] Delete `scripts/check_pipfile_and_toxini.py` (obsolete)
+- [ ] Delete `scripts/spell-check.sh` (-> tomte)
+- [ ] Delete `scripts/log_parser.py` (unused)
+- [ ] Delete `scripts/check_doc_ipfs_hashes.py` (-> aea-helpers `check-doc-hashes`)
+- [ ] Delete `scripts/check_dependencies.py` (-> aea-helpers `check-dependencies`)
+
+### Step 2d: Release
+
+- [ ] Release `open-aea-ci-helpers` to PyPI (initial version, e.g., `0.1.0`)
+- [ ] Release `open-aea` with the tox.ini changes (patch version bump)
+
+**Duration:** 2-3 days
+
+---
+
+## Phase 3: open-autonomy
+
+**Scope:** Switch open-autonomy to use tomte + `open-aea-ci-helpers` instead of local scripts. Rename `aea-helpers` to `open-aea-helpers` on PyPI. Delete duplicate scripts.
+
+**Repo:** `valory-xyz/open-autonomy`
+
+### Step 3a: Switch open-autonomy's tox.ini
+
+- [ ] Add `open-aea-ci-helpers` as a tox dep
+- [ ] Replace `scripts/check_copyright.py` invocations with `tomte check-copyright`
+- [ ] Replace `scripts/check_doc_links.py` invocations with `tomte check-doc-links`
+- [ ] Replace `scripts/freeze_dependencies.py` invocations with `tomte freeze-dependencies`
+- [ ] Replace `scripts/check_ipfs_hashes_pushed.py` invocations with `aea-ci check-ipfs-pushed`
+- [ ] Replace `scripts/generate_api_documentation.py` invocations with `aea-ci generate-api-docs`
+- [ ] Replace `scripts/generate_package_list.py` invocations with `aea-ci generate-pkg-list`
+- [ ] Verify CI passes
+
+### Step 3b: Delete duplicate scripts
+
+- [ ] Delete `scripts/check_copyright.py`
+- [ ] Delete `scripts/check_doc_links.py`
+- [ ] Delete `scripts/freeze_dependencies.py`
+- [ ] Delete `scripts/check_ipfs_hashes_pushed.py`
+- [ ] Delete `scripts/generate_api_documentation.py`
+- [ ] Delete `scripts/generate_package_list.py`
+
+### Step 3c: Rename aea-helpers -> open-aea-helpers on PyPI
+
+- [ ] Update `plugins/aea-helpers/setup.py`: change `name="aea-helpers"` to `name="open-aea-helpers"`
+- [ ] Python package (`aea_helpers`) and CLI command (`aea-helpers`) remain unchanged
+- [ ] Verify linters and tests pass
+- [ ] Publish `open-aea-helpers` to PyPI (same version as current `aea-helpers`, e.g., `0.21.17`)
+- [ ] Publish a final `aea-helpers` version on PyPI that depends on `open-aea-helpers` (bridge package for backwards compat, optional)
+
+### Step 3d: Release
+
+- [ ] Release `open-autonomy` with all changes
+- [ ] Delete `SCRIPTS_CONSOLIDATION_REPORT.md` and `SCRIPTS_CONSOLIDATION_IMPLEMENTATION_PLAN.md` from repo
+
+**Duration:** 1-2 days
+
+---
+
+## Phase 4: Mech repos (6 repos)
+
+**Scope:** Update dependency references from `aea-helpers` to `open-aea-helpers` and from local scripts (if any) to `tomte` / `aea-ci`.
+
+**Repos:**
+1. `valory-xyz/mech`
+2. `valory-xyz/mech-interact`
+3. `valory-xyz/mech-client`
+4. `valory-xyz/mech-predict`
+5. `valory-xyz/mech-server`
+6. `valory-xyz/mech-agents-fun`
+
+### Per-repo tasks
+
+- [ ] Update `pyproject.toml`: `aea-helpers==X.Y.Z` -> `open-aea-helpers==X.Y.Z`
+- [ ] Update `tox.ini`: any `aea-helpers` references
+- [ ] Bump `open-aea` and `open-autonomy` version pins if needed
+- [ ] Verify CI passes
+- [ ] Create PR per repo
+
+**Duration:** 1 day (batch all 6)
+
+---
+
+## Phase 5: Library repos (3 repos)
+
+**Scope:** Same dependency update as Phase 4.
+
+**Repos:**
+1. `valory-xyz/genai`
+2. `valory-xyz/funds-manager`
+3. `valory-xyz/kv-store`
+
+### Per-repo tasks
+
+- [ ] Update `pyproject.toml`: `aea-helpers==X.Y.Z` -> `open-aea-helpers==X.Y.Z`
+- [ ] Update `tox.ini`: any `aea-helpers` references
+- [ ] Bump `open-aea` and `open-autonomy` version pins if needed
+- [ ] Verify CI passes
+- [ ] Create PR per repo
+
+**Duration:** 0.5 day (batch all 3)
+
+---
+
+## Phase 6: Agent repos (5 repos)
+
+**Scope:** Same dependency update as Phase 4. These repos also have the cleanup PRs from the earlier effort that may need rebasing.
+
+**Repos:**
+1. `valory-xyz/optimus`
+2. `valory-xyz/trader`
+3. `valory-xyz/meme-ooorr`
+4. `valory-xyz/IEKit`
+5. `valory-xyz/market-creator`
+
+### Per-repo tasks
+
+- [ ] Update `pyproject.toml`: `aea-helpers==X.Y.Z` -> `open-aea-helpers==X.Y.Z`
+- [ ] Update `tox.ini`: any `aea-helpers` references
+- [ ] Update `Makefile`: any `aea-helpers` CLI invocations (these already use `aea-helpers` CLI — the binary name doesn't change, only the pip package name)
+- [ ] Bump `open-aea` and `open-autonomy` version pins if needed
+- [ ] Rebase existing cleanup PRs if still open
+- [ ] Verify CI passes
+- [ ] Create PR per repo
+
+**Duration:** 1 day (batch all 5)
+
+---
+
+## Phase 7: Cleanup
+
+**Scope:** Final housekeeping.
+
+- [ ] Verify old `aea-helpers` PyPI package has a deprecation notice or redirect
+- [ ] Remove `SCRIPTS_CONSOLIDATION_REPORT.md` and this plan from open-autonomy
+- [ ] Update CLAUDE.md / README in open-aea and open-autonomy to document the new plugin structure
+- [ ] Close any related tracking issues
+
+**Duration:** 0.5 day
+
+---
+
+## Summary
+
+| Phase | Repo(s) | What | Duration |
+|-------|---------|------|----------|
+| 0 | — | Preparation & sign-off | 1 day |
+| 1 | tomte | Verify/fix feature parity | 1-3 days |
+| 2 | open-aea | Create open-aea-ci-helpers, switch to tomte, delete scripts | 2-3 days |
+| 3 | open-autonomy | Switch to tomte + aea-ci, rename aea-helpers, delete duplicates | 1-2 days |
+| 4 | 6 mech repos | Update aea-helpers -> open-aea-helpers | 1 day |
+| 5 | 3 library repos | Same | 0.5 day |
+| 6 | 5 agent repos | Same + rebase cleanup PRs | 1 day |
+| 7 | All | Final cleanup | 0.5 day |
+| **Total** | | | **7-11 days** |
+
+### Critical path
+
+```
+Phase 0 -> Phase 1 -> Phase 2 -> Phase 3 -> Phase 4/5/6 (parallel) -> Phase 7
+```
+
+Phases 4, 5, and 6 can run in parallel once Phase 3 is released.

--- a/SCRIPTS_CONSOLIDATION_IMPLEMENTATION_PLAN.md
+++ b/SCRIPTS_CONSOLIDATION_IMPLEMENTATION_PLAN.md
@@ -28,22 +28,82 @@ Phased rollout plan for the changes described in `SCRIPTS_CONSOLIDATION_REPORT.m
 
 ---
 
-## Phase 1: tomte
+## Phase 1: tomte enhancements
 
-**Scope:** Ensure tomte covers all the scripts we want to delegate to it. If any gaps exist (different CLI flags, missing features), fix them in tomte first.
+**Scope:** Enhance tomte to close the feature gaps identified during comparison. Three enhancements are needed before tomte can replace the local scripts.
 
 **Repo:** `valory-xyz/tomte`
 
+### Gap analysis (completed)
+
+| Script | Gap | Status |
+|--------|-----|--------|
+| `check-copyright` | Only supports single author ("Valory AG"). open-aea has 751 files with dual "Valory AG" + "Fetch.AI Limited" headers. Also hardcodes scan paths. | Needs enhancement |
+| `check-doc-links` | open-aea's version is fundamentally different (validates internal links, images, markdown). open-autonomy's is close to tomte's but has repo-specific skip lists hardcoded. | Needs `--http-skips` / `--url-skips` already exist as CLI options — sufficient for open-autonomy. open-aea keeps its own script (different tool). |
+| `freeze-dependencies` | Tomte doesn't filter out the framework package itself. open-aea filters `aea`, open-autonomy filters `open-autonomy`. Without filtering, liccheck checks the framework against itself. | Needs enhancement |
+| `check-spelling` | Tomte's version is sufficient. | No changes needed |
+
+### Enhancement 1: `check-copyright` — multiple authors + configurable scan paths
+
+**Current:** `tomte check-copyright --author "Valory AG"`
+
+**Proposed:**
+```bash
+# Multiple authors (repeatable flag)
+tomte check-copyright --author "Valory AG" --author "Fetch.AI Limited"
+
+# Configurable scan paths (repeatable flag, overrides defaults)
+tomte check-copyright --author "Valory AG" --scan-path aea --scan-path packages --scan-path plugins
+
+# Combined (for open-aea)
+tomte check-copyright \
+  --author "Valory AG" \
+  --author "Fetch.AI Limited" \
+  --scan-path aea --scan-path packages --scan-path plugins \
+  --scan-path scripts --scan-path tests --scan-path benchmark --scan-path examples
+```
+
+**Implementation:**
+- [ ] Make `--author` repeatable (`multiple=True` in Click)
+- [ ] Support multiple copyright header patterns (one per author)
+- [ ] In check mode: validate that at least one recognized author header is present
+- [ ] In fix mode: update year ranges for all recognized author lines
+- [ ] Add `--scan-path` repeatable option (defaults to `packages/{author}`, `tests`, `scripts` if not provided)
+- [ ] Support mixed headers (Valory + FetchAI on same file) without error
+- [ ] Tests for multi-author scenarios
+
+### Enhancement 2: `freeze-dependencies` — exclude package filter
+
+**Current:** `tomte freeze-dependencies --output-path requirements.txt`
+
+**Proposed:**
+```bash
+# Exclude framework package from output
+tomte freeze-dependencies --output-path requirements.txt --exclude-package open-autonomy
+tomte freeze-dependencies --output-path requirements.txt --exclude-package open-aea
+```
+
+**Implementation:**
+- [ ] Add `--exclude-package` repeatable option
+- [ ] Filter out matching lines from pip freeze output (regex: `^{package}(==.*| .*)?$`)
+- [ ] Tests for exclusion
+
+### Enhancement 3: `check-doc-links` — no code changes needed
+
+Tomte's `check-doc-links` already accepts `--http-skips` and `--url-skips` as CLI options. open-autonomy can pass its repo-specific skip lists via tox.ini. No tomte changes required.
+
+**Note:** open-aea's `check_doc_links.py` is a fundamentally different tool (validates internal links, images, markdown structure) and will NOT be replaced by tomte. It moves to `open-aea-ci-helpers` instead.
+
 ### Tasks
 
-- [ ] Compare `tomte check-copyright` vs `open-aea/scripts/check_copyright_notice.py` — verify feature parity (author detection, year updating, exclude patterns)
-- [ ] Compare `tomte check-doc-links` vs `open-aea/scripts/check_doc_links.py` — verify feature parity (retry logic, skip patterns, timeout handling)
-- [ ] Compare `tomte freeze-dependencies` vs `open-aea/scripts/freeze_dependencies.py` — verify feature parity
-- [ ] Compare `tomte check-spelling` vs `open-aea/scripts/spell-check.sh` — verify feature parity
-- [ ] If any gaps: submit PRs to tomte, get them released
-- [ ] Release new tomte version if needed (e.g., `0.6.3`)
+- [ ] Implement Enhancement 1 (check-copyright multi-author + scan paths)
+- [ ] Implement Enhancement 2 (freeze-dependencies exclude filter)
+- [ ] Add/update tests for both enhancements
+- [ ] Run tomte's own CI locally and confirm it passes
+- [ ] Create draft PR for tomte
+- [ ] Release new tomte version (e.g., `0.6.3`)
 
-**Duration:** 1 day (if no gaps) / 2-3 days (if gaps need fixing)
+**Duration:** 2-3 days
 
 ---
 

--- a/SCRIPTS_CONSOLIDATION_IMPLEMENTATION_PLAN.md
+++ b/SCRIPTS_CONSOLIDATION_IMPLEMENTATION_PLAN.md
@@ -2,6 +2,18 @@
 
 Phased rollout plan for the changes described in `SCRIPTS_CONSOLIDATION_REPORT.md`.
 
+### Ground rules
+
+1. **Local CI first.** Every phase must pass the repo's full CI suite locally before creating a draft PR. Run the full common/main workflow checks (linters, hash checks, copyright, tests) locally via `tox` or `make` and confirm they pass. Do not rely on remote CI to catch issues — fix them before pushing.
+
+2. **Fresh branch from latest main.** For every repo (except the 5 agent repos which have existing cleanup branches), always start from a clean state:
+   ```bash
+   git checkout main
+   git pull origin main
+   git checkout -b <branch-name>
+   ```
+   Agent repos (optimus, trader, meme-ooorr, IEKit, market-creator) already have `chore/repo-cleanup` branches — rebase those onto latest main instead of creating new branches.
+
 ---
 
 ## Phase 0: Preparation
@@ -83,8 +95,25 @@ Phased rollout plan for the changes described in `SCRIPTS_CONSOLIDATION_REPORT.m
 - [ ] Delete `scripts/check_doc_ipfs_hashes.py` (-> aea-helpers `check-doc-hashes`)
 - [ ] Delete `scripts/check_dependencies.py` (-> aea-helpers `check-dependencies`)
 
-### Step 2d: Release
+### Step 2d: Local CI verification
 
+Run the full CI suite locally before creating the PR:
+
+```bash
+make clean
+make formatters
+make code-checks
+make security
+make common-checks-1
+make common-checks-2
+make test
+```
+
+Fix any failures before pushing.
+
+### Step 2e: Release
+
+- [ ] Create draft PR, confirm remote CI passes
 - [ ] Release `open-aea-ci-helpers` to PyPI (initial version, e.g., `0.1.0`)
 - [ ] Release `open-aea` with the tox.ini changes (patch version bump)
 
@@ -126,8 +155,26 @@ Phased rollout plan for the changes described in `SCRIPTS_CONSOLIDATION_REPORT.m
 - [ ] Publish `open-aea-helpers` to PyPI (same version as current `aea-helpers`, e.g., `0.21.17`)
 - [ ] Publish a final `aea-helpers` version on PyPI that depends on `open-aea-helpers` (bridge package for backwards compat, optional)
 
-### Step 3d: Release
+### Step 3d: Local CI verification
 
+Run the full CI suite locally before creating the PR:
+
+```bash
+make clean
+tomte format-code
+tomte check-code
+make security
+make common-checks-1
+make common-checks-2
+make test
+```
+
+Fix any failures before pushing.
+
+### Step 3e: Release
+
+- [ ] Create draft PR, confirm remote CI passes
+- [ ] Release `open-aea-helpers` to PyPI (renamed from `aea-helpers`)
 - [ ] Release `open-autonomy` with all changes
 - [ ] Delete `SCRIPTS_CONSOLIDATION_REPORT.md` and `SCRIPTS_CONSOLIDATION_IMPLEMENTATION_PLAN.md` from repo
 
@@ -152,8 +199,8 @@ Phased rollout plan for the changes described in `SCRIPTS_CONSOLIDATION_REPORT.m
 - [ ] Update `pyproject.toml`: `aea-helpers==X.Y.Z` -> `open-aea-helpers==X.Y.Z`
 - [ ] Update `tox.ini`: any `aea-helpers` references
 - [ ] Bump `open-aea` and `open-autonomy` version pins if needed
-- [ ] Verify CI passes
-- [ ] Create PR per repo
+- [ ] Run full CI locally (`make all-checks` or equivalent) and fix any failures
+- [ ] Create draft PR per repo only after local CI passes
 
 **Duration:** 1 day (batch all 6)
 
@@ -173,8 +220,8 @@ Phased rollout plan for the changes described in `SCRIPTS_CONSOLIDATION_REPORT.m
 - [ ] Update `pyproject.toml`: `aea-helpers==X.Y.Z` -> `open-aea-helpers==X.Y.Z`
 - [ ] Update `tox.ini`: any `aea-helpers` references
 - [ ] Bump `open-aea` and `open-autonomy` version pins if needed
-- [ ] Verify CI passes
-- [ ] Create PR per repo
+- [ ] Run full CI locally and fix any failures
+- [ ] Create draft PR per repo only after local CI passes
 
 **Duration:** 0.5 day (batch all 3)
 
@@ -198,8 +245,8 @@ Phased rollout plan for the changes described in `SCRIPTS_CONSOLIDATION_REPORT.m
 - [ ] Update `Makefile`: any `aea-helpers` CLI invocations (these already use `aea-helpers` CLI — the binary name doesn't change, only the pip package name)
 - [ ] Bump `open-aea` and `open-autonomy` version pins if needed
 - [ ] Rebase existing cleanup PRs if still open
-- [ ] Verify CI passes
-- [ ] Create PR per repo
+- [ ] Run full CI locally (`make all-checks` or equivalent) and fix any failures
+- [ ] Create draft PR per repo only after local CI passes
 
 **Duration:** 1 day (batch all 5)
 

--- a/SCRIPTS_CONSOLIDATION_REPORT.md
+++ b/SCRIPTS_CONSOLIDATION_REPORT.md
@@ -146,15 +146,42 @@ open-aea/
 ```
 tomte                       (independent, MIT licensed, no aea/autonomy dep)
 open-aea-ci-helpers     ->  open-aea (only)
-aea-helpers             ->  open-autonomy -> open-aea
+open-aea-helpers        ->  open-autonomy -> open-aea    (renamed from aea-helpers)
 open-aea-test-autonomy  ->  open-autonomy -> open-aea
 
 open-aea uses:         tomte + open-aea-ci-helpers (no circular dep)
-open-autonomy uses:    tomte + open-aea-ci-helpers + aea-helpers + open-aea-test-autonomy
-downstream repos use:  tomte + open-aea-ci-helpers (optional) + aea-helpers + open-aea-test-autonomy
+open-autonomy uses:    tomte + open-aea-ci-helpers + open-aea-helpers + open-aea-test-autonomy
+downstream repos use:  tomte + open-aea-ci-helpers (optional) + open-aea-helpers + open-aea-test-autonomy
 ```
 
 No circular dependencies.
+
+---
+
+## Rename `aea-helpers` -> `open-aea-helpers`
+
+The existing `aea-helpers` plugin is the **only** plugin across both repos that does not follow the `open-` prefix PyPI naming convention:
+
+| Plugin dir | Current PyPI name | Convention-compliant? |
+|---|---|---|
+| All 8 open-aea plugins | `open-aea-*` | Yes |
+| `aea-test-autonomy` | `open-aea-test-autonomy` | Yes |
+| **`aea-helpers`** | **`aea-helpers`** | **No** |
+
+**Proposed rename:**
+
+| | Current | After |
+|---|---|---|
+| Plugin directory | `aea-helpers` | `aea-helpers` (no change) |
+| Python package | `aea_helpers` | `aea_helpers` (no change — avoids breaking imports) |
+| **PyPI package** | `aea-helpers` | **`open-aea-helpers`** |
+| CLI command | `aea-helpers` | `aea-helpers` (no change) |
+
+Only the PyPI `name` field in `setup.py` changes. Python imports (`from aea_helpers import ...`) and the CLI command (`aea-helpers run-agent`) remain the same.
+
+**Migration for downstream repos:** Update `pyproject.toml` / `tox.ini` from `aea-helpers==X.Y.Z` to `open-aea-helpers==X.Y.Z`. This can be done in the same release cycle as the other changes.
+
+**Affected repos:** optimus, trader, meme-ooorr, IEKit, market-creator, and any other repo that depends on `aea-helpers`.
 
 ---
 
@@ -194,4 +221,5 @@ No circular dependencies.
 | Step 2: Create open-aea-ci-helpers | 2-3 days | None |
 | Step 3: Remove OA duplicates | 1 day | Step 2 |
 | Step 4: Delete obsolete | 1 hour | Step 1 |
-| **Total** | **4-5 days** | |
+| Step 5: Rename aea-helpers -> open-aea-helpers | 0.5 day | Coordinate with downstream repos |
+| **Total** | **5-6 days** | |

--- a/SCRIPTS_CONSOLIDATION_REPORT.md
+++ b/SCRIPTS_CONSOLIDATION_REPORT.md
@@ -11,11 +11,11 @@ There are **four** tools that downstream repos depend on:
 | **`autonomy` CLI** | Package management, FSM analysis, deployments | `open-autonomy/autonomy/cli/` | `open-autonomy -> open-aea` |
 | **`aea-helpers`** | Agent runtime + CI helpers | `open-autonomy/plugins/aea-helpers/` | `aea-helpers -> open-autonomy -> open-aea` |
 | **`aea-test-autonomy`** | Test infrastructure (Docker fixtures, base classes) | `open-autonomy/plugins/aea-test-autonomy/` | `aea-test-autonomy -> open-autonomy` |
-| **`tomte`** | Linting meta-package (black, isort, flake8, mypy, etc.) | Separate repo (`valory-xyz/tomte`) | No aea/autonomy dep |
+| **`tomte`** | Linting meta-package + CLI (black, isort, flake8, mypy, copyright, doc-links, etc.) | Separate repo (`valory-xyz/tomte`) | No aea/autonomy dep, MIT licensed |
 
 Downstream repos use these cleanly: `tomte` for code quality, `autonomy` CLI for package ops, `aea-helpers` for runtime/CI, `aea-test-autonomy` for test infra. **No downstream repo calls `scripts/` directly.**
 
-The problem is that `open-aea` and `open-autonomy` themselves still have `scripts/` directories with ~30 scripts between them, many duplicated.
+The problem is that `open-aea` and `open-autonomy` themselves still have `scripts/` directories with ~30 scripts between them, many duplicated — and some are near-identical copies of what `tomte` already provides.
 
 ---
 
@@ -23,43 +23,43 @@ The problem is that `open-aea` and `open-autonomy` themselves still have `script
 
 #### open-aea/scripts/ (22 files)
 
-| Script | Purpose | Invoked by | Could migrate? |
-|--------|---------|-----------|----------------|
-| `check_copyright_notice.py` | Validate/fix copyright headers | `tox -e check-copyright`, `tox -e fix-copyright` | Yes -> `aea-ci-helpers` |
-| `check_doc_links.py` | Validate doc HTTP links are reachable | `tox -e check-doc-links-hashes` | Yes -> `aea-ci-helpers` |
-| `check_doc_ipfs_hashes.py` | Validate/fix IPFS hashes in docs | `tox -e check-doc-links-hashes`, `tox -e fix-doc-hashes` | Already in aea-helpers as `check-doc-hashes` |
-| `check_ipfs_hashes_pushed.py` | Verify IPFS hashes are reachable on gateway | `tox -e check-doc-links-hashes` | Yes -> `aea-ci-helpers` |
+| Script | Purpose | Invoked by | Migration target |
+|--------|---------|-----------|-----------------|
+| `check_copyright_notice.py` | Validate/fix copyright headers | `tox -e check-copyright`, `tox -e fix-copyright` | **Use `tomte check-copyright`** (tomte already has this) |
+| `check_doc_links.py` | Validate doc HTTP links are reachable | `tox -e check-doc-links-hashes` | **Use `tomte check-doc-links`** (tomte already has this) |
+| `check_doc_ipfs_hashes.py` | Validate/fix IPFS hashes in docs | `tox -e fix-doc-hashes` | Already in aea-helpers as `check-doc-hashes` |
+| `check_ipfs_hashes_pushed.py` | Verify IPFS hashes are reachable on gateway | `tox -e check-doc-links-hashes` | `open-aea-ci-helpers` |
 | `check_dependencies.py` | Verify installed deps match Pipfile | `tox -e dependencies-check` | Already in aea-helpers as `check-dependencies` |
-| `check_imports_and_dependencies.py` | Verify imports match declared deps | `tox -e dependencies-check` | Yes -> `aea-ci-helpers` |
-| `check_package_versions_in_docs.py` | Verify package IDs in docs match configs | `tox -e package-version-checks` | Yes -> `aea-ci-helpers` |
-| `check_pipfile_and_toxini.py` | Verify Pipfile and tox.ini specs match | Development use | Obsolete (repos moved to uv) |
-| `check_pyproject_and_toxini.py` | Verify pyproject.toml and tox.ini align | GitHub Actions workflow | Yes -> `aea-ci-helpers` |
-| `freeze_dependencies.py` | Freeze pip env to requirements.txt | `tox -e liccheck` | Yes -> `aea-ci-helpers` |
-| `generate_api_docs.py` | Generate API docs from source | `tox -e check-api-docs`, `tox -e generate-api-documentation` | Yes -> `aea-ci-helpers` |
-| `generate_package_list.py` | Generate markdown table of packages | `tox -e fix-doc-hashes` | Yes -> `aea-ci-helpers` |
+| `check_imports_and_dependencies.py` | Verify imports match declared deps | `tox -e dependencies-check` | `open-aea-ci-helpers` |
+| `check_package_versions_in_docs.py` | Verify package IDs in docs match configs | `tox -e package-version-checks` | `open-aea-ci-helpers` |
+| `check_pipfile_and_toxini.py` | Verify Pipfile and tox.ini specs match | Development use | **Delete** (obsolete — repos moved to uv/pyproject.toml) |
+| `check_pyproject_and_toxini.py` | Verify pyproject.toml and tox.ini align | GitHub Actions workflow | `open-aea-ci-helpers` |
+| `freeze_dependencies.py` | Freeze pip env to requirements.txt | `tox -e liccheck` | **Use `tomte freeze-dependencies`** (tomte already has this) |
+| `generate_api_docs.py` | Generate API docs from source | `tox -e check-api-docs`, `tox -e generate-api-documentation` | `open-aea-ci-helpers` |
+| `generate_package_list.py` | Generate markdown table of packages | `tox -e fix-doc-hashes` | `open-aea-ci-helpers` |
 | `bump_aea_version.py` | Bump version across codebase | Release process (manual) | Keep in open-aea (repo-specific) |
 | `update_package_versions.py` | Update package versions + rehash | Release process (manual) | Keep in open-aea (repo-specific) |
 | `update_plugin_versions.py` | Update plugin versions | Release process (manual) | Keep in open-aea (repo-specific) |
 | `deploy_to_registry.py` | Deploy packages to AEA registry | Manual/CI deployment | Keep in open-aea (repo-specific) |
 | `publish_packages_to_local_registry.py` | Publish to IPFS | Manual deployment | Keep in open-aea (repo-specific) |
-| `spell-check.sh` | Markdown spell check | `tox -e spell-check` | Already handled by `tomte check-spelling` |
+| `spell-check.sh` | Markdown spell check | `tox -e spell-check` | **Delete** (use `tomte check-spelling`) |
 | `whitelist.py` | Vulture dead code allowlist | `tox -e vulture` | Keep (data file, not a script) |
-| `log_parser.py` | Parse profiling logs | Standalone utility | Keep or delete (unused in CI) |
+| `log_parser.py` | Parse profiling logs | Standalone utility | **Delete** (unused in CI) |
 | `install.sh` / `install.ps1` | End-user installers | Direct download | Keep in open-aea |
 | `acn/` | ACN node runner | Manual deployment | Keep in open-aea |
 | `update_symlinks_cross_platform.py` | Create test fixture symlinks | GitHub Actions | Keep in open-aea (repo-specific) |
 
 #### open-autonomy/scripts/ (11 files)
 
-| Script | Purpose | Invoked by | Could migrate? |
-|--------|---------|-----------|----------------|
-| `check_copyright.py` | Validate/fix copyright headers | `tox -e check-copyright`, `tox -e fix-copyright` | **DUPLICATE** of open-aea's version -> `aea-ci-helpers` |
-| `check_doc_links.py` | Validate doc HTTP links | `tox -e check-doc-links` | **DUPLICATE** -> `aea-ci-helpers` |
-| `check_ipfs_hashes_pushed.py` | Verify IPFS hashes on gateway | `tox -e check-ipfs-hashes-pushed` | **DUPLICATE** -> `aea-ci-helpers` |
-| `check_third_party_hashes.py` | Cross-ref hashes with open-aea | `tox -e check-packages` | Yes -> `aea-ci-helpers` |
-| `freeze_dependencies.py` | Freeze pip env | Not directly invoked | **DUPLICATE** -> `aea-ci-helpers` |
-| `generate_api_documentation.py` | Generate API docs | `tox -e check-api-docs`, `tox -e generate-api-documentation` | **DUPLICATE** -> `aea-ci-helpers` |
-| `generate_package_list.py` | Generate package markdown | `tox -e generate-package-list` | **DUPLICATE** -> `aea-ci-helpers` |
+| Script | Purpose | Invoked by | Migration target |
+|--------|---------|-----------|-----------------|
+| `check_copyright.py` | Validate/fix copyright headers | `tox -e check-copyright`, `tox -e fix-copyright` | **Use `tomte check-copyright`** (DUPLICATE — delete) |
+| `check_doc_links.py` | Validate doc HTTP links | `tox -e check-doc-links` | **Use `tomte check-doc-links`** (DUPLICATE — delete) |
+| `check_ipfs_hashes_pushed.py` | Verify IPFS hashes on gateway | `tox -e check-ipfs-hashes-pushed` | **DUPLICATE** -> `open-aea-ci-helpers` |
+| `check_third_party_hashes.py` | Cross-ref hashes with open-aea | `tox -e check-packages` | `open-aea-ci-helpers` |
+| `freeze_dependencies.py` | Freeze pip env | Not directly invoked | **Use `tomte freeze-dependencies`** (DUPLICATE — delete) |
+| `generate_api_documentation.py` | Generate API docs | `tox -e check-api-docs`, `tox -e generate-api-documentation` | **DUPLICATE** -> `open-aea-ci-helpers` |
+| `generate_package_list.py` | Generate package markdown | `tox -e generate-package-list` | **DUPLICATE** -> `open-aea-ci-helpers` |
 | `generate_contract_list.py` | Generate contract addresses doc | Standalone | Keep (OA-specific) |
 | `whitelist.py` | Vulture allowlist | `tox -e vulture` | Keep (data file) |
 | `pre-add` / `pre-push` | Git hooks | Manual git hook install | Keep or move to `.githooks/` |
@@ -67,116 +67,100 @@ The problem is that `open-aea` and `open-autonomy` themselves still have `script
 
 ---
 
-## Proposal: New plugin structure
+## Migration strategy
 
-### Split aea-helpers into two plugins
+### Step 1: Switch to tomte for overlapping scripts
+
+`tomte` already provides its own standalone implementations of these tools (inside `tomte.tools.*`). The local `scripts/` copies in both repos are near-identical duplicates. Downstream repos already use `tomte` for these successfully.
+
+**Scripts to replace with tomte:**
+
+| Local script | Replace with | Notes |
+|-------------|-------------|-------|
+| `check_copyright_notice.py` (open-aea) | `tomte check-copyright` | Downstream repos already use this |
+| `check_copyright.py` (open-autonomy) | `tomte check-copyright` | Same |
+| `check_doc_links.py` (both repos) | `tomte check-doc-links` | Same |
+| `freeze_dependencies.py` (both repos) | `tomte freeze-dependencies` | Same |
+| `spell-check.sh` (open-aea) | `tomte check-spelling` | Same |
+
+**Action:** Update `tox.ini` in both repos to call `tomte <command>` instead of `scripts/<script>.py`, then delete the local copies.
+
+### Step 2: Create `open-aea-ci-helpers` plugin
+
+For scripts that tomte does NOT cover, create a new plugin in `open-aea/plugins/`:
 
 ```
 open-aea/
   plugins/
-    aea-ci-helpers/          # NEW — generic CI tooling, no autonomy dep
-      aea_ci_helpers/
+    aea-ci-helpers/                    # Plugin directory name
+      aea_ci_helpers/                  # Python package name
         __init__.py
-        cli.py               # Click CLI entry point
-        check_copyright.py   # From scripts/check_copyright_notice.py
-        check_doc_links.py   # From scripts/check_doc_links.py
-        check_ipfs_pushed.py # From scripts/check_ipfs_hashes_pushed.py
-        check_imports.py     # From scripts/check_imports_and_dependencies.py
-        check_pyproject.py   # From scripts/check_pyproject_and_toxini.py
-        freeze_deps.py       # From scripts/freeze_dependencies.py
-        generate_api_docs.py # From scripts/generate_api_docs.py
-        generate_pkg_list.py # From scripts/generate_package_list.py
-        check_pkg_versions.py # From scripts/check_package_versions_in_docs.py
+        cli.py                         # Click CLI entry point
+        check_ipfs_pushed.py           # From check_ipfs_hashes_pushed.py
+        check_imports.py               # From check_imports_and_dependencies.py
+        check_pyproject.py             # From check_pyproject_and_toxini.py
+        check_pkg_versions.py          # From check_package_versions_in_docs.py
+        generate_api_docs.py           # From generate_api_docs.py
+        generate_pkg_list.py           # From generate_package_list.py
       setup.py
-      # Dependencies: click, requests, pyyaml, open-aea (lightweight)
-
-open-autonomy/
-  plugins/
-    aea-helpers/             # EXISTING — autonomy-specific runtime helpers
-      aea_helpers/
-        cli.py
-        run_agent.py         # Stays (needs autonomy)
-        run_service.py       # Stays (needs autonomy)
-        config_replace.py    # Stays
-        bump_dependencies.py # Stays (needs autonomy)
-        check_dependencies.py # Stays (needs autonomy pkg manager)
-        check_doc_hashes.py  # Stays (needs autonomy pkg manager)
-        make_release.py      # Stays
-        pyinstaller_deps.py  # Stays (build-binary-deps, bin-template-path)
-        check_binary.py      # Stays
-        bin_template.py      # Stays
-      setup.py
-      # Dependencies: open-autonomy, click, ...
-
-    aea-test-autonomy/       # EXISTING — unchanged
 ```
 
-### Naming convention
+**Naming convention (following Valory's `open-` prefix convention):**
 
-| Package | PyPI name | Import name | CLI name |
-|---------|-----------|-------------|----------|
-| CI helpers | `aea-ci-helpers` | `aea_ci_helpers` | `aea-ci` |
-| Runtime helpers | `aea-helpers` | `aea_helpers` | `aea-helpers` |
-| Test infra | `aea-test-autonomy` | `aea_test_autonomy` | (pytest plugin, no CLI) |
+| | Value |
+|---|---|
+| Plugin directory | `aea-ci-helpers` |
+| Python package | `aea_ci_helpers` |
+| **PyPI package** | **`open-aea-ci-helpers`** |
+| CLI command | `aea-ci` |
 
-### Dependency chain after refactor
+**Commands:**
+- `aea-ci check-ipfs-pushed` — verify IPFS hashes are reachable on gateway
+- `aea-ci check-imports` — verify imports match declared dependencies
+- `aea-ci check-pyproject` — verify pyproject.toml and tox.ini alignment
+- `aea-ci check-pkg-versions` — verify package versions in docs match configs
+- `aea-ci generate-api-docs` — generate API documentation from source
+- `aea-ci generate-pkg-list` — generate markdown table of packages
+
+**Dependencies:** `click`, `requests`, `pyyaml`, `open-aea` (lightweight — no autonomy dependency)
+
+### Step 3: Update open-autonomy to consume the new plugin
+
+1. Add `open-aea-ci-helpers` as a tox dependency in open-autonomy
+2. Update `tox.ini` to call `aea-ci <command>` instead of `scripts/<script>.py`
+3. Delete the duplicated scripts from `open-autonomy/scripts/`
+4. Keep OA-specific: `check_third_party_hashes.py`, `generate_contract_list.py`, `whitelist.py`, git hooks
+
+### Step 4: Delete obsolete scripts
+
+| Script | Repo | Reason |
+|--------|------|--------|
+| `check_pipfile_and_toxini.py` | open-aea | Pipfile is dead, repos use uv/pyproject.toml |
+| `spell-check.sh` | open-aea | Replaced by `tomte check-spelling` |
+| `log_parser.py` | open-aea | Unused standalone utility |
+
+---
+
+## Dependency chain after refactor
 
 ```
-aea-ci-helpers -> open-aea (only)
-aea-helpers -> open-autonomy -> open-aea
-aea-test-autonomy -> open-autonomy -> open-aea
+tomte                       (independent, MIT licensed, no aea/autonomy dep)
+open-aea-ci-helpers     ->  open-aea (only)
+aea-helpers             ->  open-autonomy -> open-aea
+open-aea-test-autonomy  ->  open-autonomy -> open-aea
 
-open-aea uses: aea-ci-helpers (in tox, no circular dep)
-open-autonomy uses: aea-ci-helpers + aea-helpers + aea-test-autonomy
-downstream repos use: aea-ci-helpers + aea-helpers + aea-test-autonomy + tomte
+open-aea uses:         tomte + open-aea-ci-helpers (no circular dep)
+open-autonomy uses:    tomte + open-aea-ci-helpers + aea-helpers + open-aea-test-autonomy
+downstream repos use:  tomte + open-aea-ci-helpers (optional) + aea-helpers + open-aea-test-autonomy
 ```
 
 No circular dependencies.
 
 ---
 
-## Migration plan
-
-### Phase 1: Create `aea-ci-helpers` in open-aea
-
-1. Create `open-aea/plugins/aea-ci-helpers/` with setup.py
-2. Migrate the 9 generic scripts as Click subcommands:
-   - `aea-ci check-copyright` (from `check_copyright_notice.py`)
-   - `aea-ci check-doc-links` (from `check_doc_links.py`)
-   - `aea-ci check-ipfs-pushed` (from `check_ipfs_hashes_pushed.py`)
-   - `aea-ci check-imports` (from `check_imports_and_dependencies.py`)
-   - `aea-ci check-pyproject` (from `check_pyproject_and_toxini.py`)
-   - `aea-ci check-pkg-versions` (from `check_package_versions_in_docs.py`)
-   - `aea-ci freeze-deps` (from `freeze_dependencies.py`)
-   - `aea-ci generate-api-docs` (from `generate_api_docs.py`)
-   - `aea-ci generate-pkg-list` (from `generate_package_list.py`)
-3. Update open-aea's `tox.ini` to call `aea-ci <command>` instead of `scripts/<script>.py`
-4. Delete migrated scripts from `open-aea/scripts/`
-5. Keep repo-specific scripts: `bump_aea_version.py`, `update_*.py`, `deploy_*.py`, `publish_*.py`, `install.*`, `acn/`, `whitelist.py`
-
-### Phase 2: Remove duplicates from open-autonomy
-
-1. Add `aea-ci-helpers` as a dependency of open-autonomy (in tox.ini test deps)
-2. Update open-autonomy's `tox.ini` to call `aea-ci <command>` instead of `scripts/<script>.py`
-3. Delete duplicated scripts: `check_copyright.py`, `check_doc_links.py`, `check_ipfs_hashes_pushed.py`, `freeze_dependencies.py`, `generate_api_documentation.py`, `generate_package_list.py`
-4. Keep OA-specific: `check_third_party_hashes.py`, `generate_contract_list.py`, `whitelist.py`, git hooks, `RELEASE_PROCESS.md`
-
-### Phase 3: Downstream repos
-
-Downstream repos already use `aea-helpers` and `tomte`. They may optionally add `aea-ci-helpers` for local dev, but most CI checks are already handled by `tomte` + `aea-helpers` at the downstream level. No mandatory changes.
-
-### Phase 4: Cleanup obsolete scripts
-
-1. Delete `check_pipfile_and_toxini.py` from open-aea (Pipfile is dead, repos use uv/pyproject.toml)
-2. Delete `spell-check.sh` from open-aea (handled by `tomte check-spelling`)
-3. Delete `log_parser.py` from open-aea (unused standalone utility)
-4. Move `NOTES.md` and `RELEASE_PROCESS.md` to `docs/` if appropriate
-
----
-
 ## What stays in scripts/ after cleanup
 
-### open-aea/scripts/ (kept)
+### open-aea/scripts/ (9 files kept)
 
 | Script | Reason to keep |
 |--------|---------------|
@@ -190,7 +174,7 @@ Downstream repos already use `aea-helpers` and `tomte`. They may optionally add 
 | `install.sh` / `install.ps1` | End-user installers |
 | `acn/` | ACN node binary |
 
-### open-autonomy/scripts/ (kept)
+### open-autonomy/scripts/ (5 files kept)
 
 | Script | Reason to keep |
 |--------|---------------|
@@ -202,26 +186,12 @@ Downstream repos already use `aea-helpers` and `tomte`. They may optionally add 
 
 ---
 
-## Overlap with tomte
-
-`tomte` already provides some of the same functionality via its CLI:
-- `tomte check-copyright` — overlaps with `check_copyright_notice.py`
-- `tomte check-doc-links` — overlaps with `check_doc_links.py`
-- `tomte check-spelling` — overlaps with `spell-check.sh`
-- `tomte freeze-dependencies` — overlaps with `freeze_dependencies.py`
-
-**Recommendation:** Downstream repos already use `tomte` for these. The question is whether open-aea and open-autonomy should also use `tomte` instead of their own scripts. If so, `aea-ci-helpers` would only need the scripts that tomte does NOT cover (check-ipfs-pushed, check-imports, generate-api-docs, generate-pkg-list, check-pyproject, check-pkg-versions).
-
-This reduces `aea-ci-helpers` to ~6 commands instead of 9.
-
----
-
 ## Effort estimate
 
 | Phase | Effort | Dependencies |
 |-------|--------|-------------|
-| Phase 1: Create aea-ci-helpers | 2-3 days | None |
-| Phase 2: Remove OA duplicates | 1 day | Phase 1 |
-| Phase 3: Downstream (optional) | N/A | No changes needed |
-| Phase 4: Delete obsolete | 1 hour | Phase 1 + 2 |
-| **Total** | **3-4 days** | |
+| Step 1: Switch to tomte | 1 day | None (tomte already installed) |
+| Step 2: Create open-aea-ci-helpers | 2-3 days | None |
+| Step 3: Remove OA duplicates | 1 day | Step 2 |
+| Step 4: Delete obsolete | 1 hour | Step 1 |
+| **Total** | **4-5 days** | |

--- a/SCRIPTS_CONSOLIDATION_REPORT.md
+++ b/SCRIPTS_CONSOLIDATION_REPORT.md
@@ -1,0 +1,227 @@
+# Scripts Consolidation Report: open-aea & open-autonomy
+
+## Current State
+
+### Tool landscape today
+
+There are **four** tools that downstream repos depend on:
+
+| Tool | What it does | Where it lives | Dep chain |
+|------|-------------|----------------|-----------|
+| **`autonomy` CLI** | Package management, FSM analysis, deployments | `open-autonomy/autonomy/cli/` | `open-autonomy -> open-aea` |
+| **`aea-helpers`** | Agent runtime + CI helpers | `open-autonomy/plugins/aea-helpers/` | `aea-helpers -> open-autonomy -> open-aea` |
+| **`aea-test-autonomy`** | Test infrastructure (Docker fixtures, base classes) | `open-autonomy/plugins/aea-test-autonomy/` | `aea-test-autonomy -> open-autonomy` |
+| **`tomte`** | Linting meta-package (black, isort, flake8, mypy, etc.) | Separate repo (`valory-xyz/tomte`) | No aea/autonomy dep |
+
+Downstream repos use these cleanly: `tomte` for code quality, `autonomy` CLI for package ops, `aea-helpers` for runtime/CI, `aea-test-autonomy` for test infra. **No downstream repo calls `scripts/` directly.**
+
+The problem is that `open-aea` and `open-autonomy` themselves still have `scripts/` directories with ~30 scripts between them, many duplicated.
+
+---
+
+### Scripts inventory
+
+#### open-aea/scripts/ (22 files)
+
+| Script | Purpose | Invoked by | Could migrate? |
+|--------|---------|-----------|----------------|
+| `check_copyright_notice.py` | Validate/fix copyright headers | `tox -e check-copyright`, `tox -e fix-copyright` | Yes -> `aea-ci-helpers` |
+| `check_doc_links.py` | Validate doc HTTP links are reachable | `tox -e check-doc-links-hashes` | Yes -> `aea-ci-helpers` |
+| `check_doc_ipfs_hashes.py` | Validate/fix IPFS hashes in docs | `tox -e check-doc-links-hashes`, `tox -e fix-doc-hashes` | Already in aea-helpers as `check-doc-hashes` |
+| `check_ipfs_hashes_pushed.py` | Verify IPFS hashes are reachable on gateway | `tox -e check-doc-links-hashes` | Yes -> `aea-ci-helpers` |
+| `check_dependencies.py` | Verify installed deps match Pipfile | `tox -e dependencies-check` | Already in aea-helpers as `check-dependencies` |
+| `check_imports_and_dependencies.py` | Verify imports match declared deps | `tox -e dependencies-check` | Yes -> `aea-ci-helpers` |
+| `check_package_versions_in_docs.py` | Verify package IDs in docs match configs | `tox -e package-version-checks` | Yes -> `aea-ci-helpers` |
+| `check_pipfile_and_toxini.py` | Verify Pipfile and tox.ini specs match | Development use | Obsolete (repos moved to uv) |
+| `check_pyproject_and_toxini.py` | Verify pyproject.toml and tox.ini align | GitHub Actions workflow | Yes -> `aea-ci-helpers` |
+| `freeze_dependencies.py` | Freeze pip env to requirements.txt | `tox -e liccheck` | Yes -> `aea-ci-helpers` |
+| `generate_api_docs.py` | Generate API docs from source | `tox -e check-api-docs`, `tox -e generate-api-documentation` | Yes -> `aea-ci-helpers` |
+| `generate_package_list.py` | Generate markdown table of packages | `tox -e fix-doc-hashes` | Yes -> `aea-ci-helpers` |
+| `bump_aea_version.py` | Bump version across codebase | Release process (manual) | Keep in open-aea (repo-specific) |
+| `update_package_versions.py` | Update package versions + rehash | Release process (manual) | Keep in open-aea (repo-specific) |
+| `update_plugin_versions.py` | Update plugin versions | Release process (manual) | Keep in open-aea (repo-specific) |
+| `deploy_to_registry.py` | Deploy packages to AEA registry | Manual/CI deployment | Keep in open-aea (repo-specific) |
+| `publish_packages_to_local_registry.py` | Publish to IPFS | Manual deployment | Keep in open-aea (repo-specific) |
+| `spell-check.sh` | Markdown spell check | `tox -e spell-check` | Already handled by `tomte check-spelling` |
+| `whitelist.py` | Vulture dead code allowlist | `tox -e vulture` | Keep (data file, not a script) |
+| `log_parser.py` | Parse profiling logs | Standalone utility | Keep or delete (unused in CI) |
+| `install.sh` / `install.ps1` | End-user installers | Direct download | Keep in open-aea |
+| `acn/` | ACN node runner | Manual deployment | Keep in open-aea |
+| `update_symlinks_cross_platform.py` | Create test fixture symlinks | GitHub Actions | Keep in open-aea (repo-specific) |
+
+#### open-autonomy/scripts/ (11 files)
+
+| Script | Purpose | Invoked by | Could migrate? |
+|--------|---------|-----------|----------------|
+| `check_copyright.py` | Validate/fix copyright headers | `tox -e check-copyright`, `tox -e fix-copyright` | **DUPLICATE** of open-aea's version -> `aea-ci-helpers` |
+| `check_doc_links.py` | Validate doc HTTP links | `tox -e check-doc-links` | **DUPLICATE** -> `aea-ci-helpers` |
+| `check_ipfs_hashes_pushed.py` | Verify IPFS hashes on gateway | `tox -e check-ipfs-hashes-pushed` | **DUPLICATE** -> `aea-ci-helpers` |
+| `check_third_party_hashes.py` | Cross-ref hashes with open-aea | `tox -e check-packages` | Yes -> `aea-ci-helpers` |
+| `freeze_dependencies.py` | Freeze pip env | Not directly invoked | **DUPLICATE** -> `aea-ci-helpers` |
+| `generate_api_documentation.py` | Generate API docs | `tox -e check-api-docs`, `tox -e generate-api-documentation` | **DUPLICATE** -> `aea-ci-helpers` |
+| `generate_package_list.py` | Generate package markdown | `tox -e generate-package-list` | **DUPLICATE** -> `aea-ci-helpers` |
+| `generate_contract_list.py` | Generate contract addresses doc | Standalone | Keep (OA-specific) |
+| `whitelist.py` | Vulture allowlist | `tox -e vulture` | Keep (data file) |
+| `pre-add` / `pre-push` | Git hooks | Manual git hook install | Keep or move to `.githooks/` |
+| `RELEASE_PROCESS.md` | Release documentation | N/A (docs) | Keep |
+
+---
+
+## Proposal: New plugin structure
+
+### Split aea-helpers into two plugins
+
+```
+open-aea/
+  plugins/
+    aea-ci-helpers/          # NEW — generic CI tooling, no autonomy dep
+      aea_ci_helpers/
+        __init__.py
+        cli.py               # Click CLI entry point
+        check_copyright.py   # From scripts/check_copyright_notice.py
+        check_doc_links.py   # From scripts/check_doc_links.py
+        check_ipfs_pushed.py # From scripts/check_ipfs_hashes_pushed.py
+        check_imports.py     # From scripts/check_imports_and_dependencies.py
+        check_pyproject.py   # From scripts/check_pyproject_and_toxini.py
+        freeze_deps.py       # From scripts/freeze_dependencies.py
+        generate_api_docs.py # From scripts/generate_api_docs.py
+        generate_pkg_list.py # From scripts/generate_package_list.py
+        check_pkg_versions.py # From scripts/check_package_versions_in_docs.py
+      setup.py
+      # Dependencies: click, requests, pyyaml, open-aea (lightweight)
+
+open-autonomy/
+  plugins/
+    aea-helpers/             # EXISTING — autonomy-specific runtime helpers
+      aea_helpers/
+        cli.py
+        run_agent.py         # Stays (needs autonomy)
+        run_service.py       # Stays (needs autonomy)
+        config_replace.py    # Stays
+        bump_dependencies.py # Stays (needs autonomy)
+        check_dependencies.py # Stays (needs autonomy pkg manager)
+        check_doc_hashes.py  # Stays (needs autonomy pkg manager)
+        make_release.py      # Stays
+        pyinstaller_deps.py  # Stays (build-binary-deps, bin-template-path)
+        check_binary.py      # Stays
+        bin_template.py      # Stays
+      setup.py
+      # Dependencies: open-autonomy, click, ...
+
+    aea-test-autonomy/       # EXISTING — unchanged
+```
+
+### Naming convention
+
+| Package | PyPI name | Import name | CLI name |
+|---------|-----------|-------------|----------|
+| CI helpers | `aea-ci-helpers` | `aea_ci_helpers` | `aea-ci` |
+| Runtime helpers | `aea-helpers` | `aea_helpers` | `aea-helpers` |
+| Test infra | `aea-test-autonomy` | `aea_test_autonomy` | (pytest plugin, no CLI) |
+
+### Dependency chain after refactor
+
+```
+aea-ci-helpers -> open-aea (only)
+aea-helpers -> open-autonomy -> open-aea
+aea-test-autonomy -> open-autonomy -> open-aea
+
+open-aea uses: aea-ci-helpers (in tox, no circular dep)
+open-autonomy uses: aea-ci-helpers + aea-helpers + aea-test-autonomy
+downstream repos use: aea-ci-helpers + aea-helpers + aea-test-autonomy + tomte
+```
+
+No circular dependencies.
+
+---
+
+## Migration plan
+
+### Phase 1: Create `aea-ci-helpers` in open-aea
+
+1. Create `open-aea/plugins/aea-ci-helpers/` with setup.py
+2. Migrate the 9 generic scripts as Click subcommands:
+   - `aea-ci check-copyright` (from `check_copyright_notice.py`)
+   - `aea-ci check-doc-links` (from `check_doc_links.py`)
+   - `aea-ci check-ipfs-pushed` (from `check_ipfs_hashes_pushed.py`)
+   - `aea-ci check-imports` (from `check_imports_and_dependencies.py`)
+   - `aea-ci check-pyproject` (from `check_pyproject_and_toxini.py`)
+   - `aea-ci check-pkg-versions` (from `check_package_versions_in_docs.py`)
+   - `aea-ci freeze-deps` (from `freeze_dependencies.py`)
+   - `aea-ci generate-api-docs` (from `generate_api_docs.py`)
+   - `aea-ci generate-pkg-list` (from `generate_package_list.py`)
+3. Update open-aea's `tox.ini` to call `aea-ci <command>` instead of `scripts/<script>.py`
+4. Delete migrated scripts from `open-aea/scripts/`
+5. Keep repo-specific scripts: `bump_aea_version.py`, `update_*.py`, `deploy_*.py`, `publish_*.py`, `install.*`, `acn/`, `whitelist.py`
+
+### Phase 2: Remove duplicates from open-autonomy
+
+1. Add `aea-ci-helpers` as a dependency of open-autonomy (in tox.ini test deps)
+2. Update open-autonomy's `tox.ini` to call `aea-ci <command>` instead of `scripts/<script>.py`
+3. Delete duplicated scripts: `check_copyright.py`, `check_doc_links.py`, `check_ipfs_hashes_pushed.py`, `freeze_dependencies.py`, `generate_api_documentation.py`, `generate_package_list.py`
+4. Keep OA-specific: `check_third_party_hashes.py`, `generate_contract_list.py`, `whitelist.py`, git hooks, `RELEASE_PROCESS.md`
+
+### Phase 3: Downstream repos
+
+Downstream repos already use `aea-helpers` and `tomte`. They may optionally add `aea-ci-helpers` for local dev, but most CI checks are already handled by `tomte` + `aea-helpers` at the downstream level. No mandatory changes.
+
+### Phase 4: Cleanup obsolete scripts
+
+1. Delete `check_pipfile_and_toxini.py` from open-aea (Pipfile is dead, repos use uv/pyproject.toml)
+2. Delete `spell-check.sh` from open-aea (handled by `tomte check-spelling`)
+3. Delete `log_parser.py` from open-aea (unused standalone utility)
+4. Move `NOTES.md` and `RELEASE_PROCESS.md` to `docs/` if appropriate
+
+---
+
+## What stays in scripts/ after cleanup
+
+### open-aea/scripts/ (kept)
+
+| Script | Reason to keep |
+|--------|---------------|
+| `bump_aea_version.py` | Release process, repo-specific |
+| `update_package_versions.py` | Release process, repo-specific |
+| `update_plugin_versions.py` | Release process, repo-specific |
+| `deploy_to_registry.py` | Deployment, repo-specific |
+| `publish_packages_to_local_registry.py` | Deployment, repo-specific |
+| `update_symlinks_cross_platform.py` | CI fixture setup, repo-specific |
+| `whitelist.py` | Vulture data file |
+| `install.sh` / `install.ps1` | End-user installers |
+| `acn/` | ACN node binary |
+
+### open-autonomy/scripts/ (kept)
+
+| Script | Reason to keep |
+|--------|---------------|
+| `check_third_party_hashes.py` | OA-specific (cross-refs with open-aea) |
+| `generate_contract_list.py` | OA-specific (fetches from registries) |
+| `whitelist.py` | Vulture data file |
+| `pre-add` / `pre-push` | Git hooks |
+| `RELEASE_PROCESS.md` | Documentation |
+
+---
+
+## Overlap with tomte
+
+`tomte` already provides some of the same functionality via its CLI:
+- `tomte check-copyright` — overlaps with `check_copyright_notice.py`
+- `tomte check-doc-links` — overlaps with `check_doc_links.py`
+- `tomte check-spelling` — overlaps with `spell-check.sh`
+- `tomte freeze-dependencies` — overlaps with `freeze_dependencies.py`
+
+**Recommendation:** Downstream repos already use `tomte` for these. The question is whether open-aea and open-autonomy should also use `tomte` instead of their own scripts. If so, `aea-ci-helpers` would only need the scripts that tomte does NOT cover (check-ipfs-pushed, check-imports, generate-api-docs, generate-pkg-list, check-pyproject, check-pkg-versions).
+
+This reduces `aea-ci-helpers` to ~6 commands instead of 9.
+
+---
+
+## Effort estimate
+
+| Phase | Effort | Dependencies |
+|-------|--------|-------------|
+| Phase 1: Create aea-ci-helpers | 2-3 days | None |
+| Phase 2: Remove OA duplicates | 1 day | Phase 1 |
+| Phase 3: Downstream (optional) | N/A | No changes needed |
+| Phase 4: Delete obsolete | 1 hour | Phase 1 + 2 |
+| **Total** | **3-4 days** | |

--- a/SCRIPTS_CONSOLIDATION_REPORT.md
+++ b/SCRIPTS_CONSOLIDATION_REPORT.md
@@ -73,17 +73,19 @@ The problem is that `open-aea` and `open-autonomy` themselves still have `script
 
 `tomte` already provides its own standalone implementations of these tools (inside `tomte.tools.*`). The local `scripts/` copies in both repos are near-identical duplicates. Downstream repos already use `tomte` for these successfully.
 
-**Scripts to replace with tomte:**
+**Scripts to replace with tomte (after tomte enhancements):**
 
 | Local script | Replace with | Notes |
 |-------------|-------------|-------|
-| `check_copyright_notice.py` (open-aea) | `tomte check-copyright` | Downstream repos already use this |
-| `check_copyright.py` (open-autonomy) | `tomte check-copyright` | Same |
-| `check_doc_links.py` (both repos) | `tomte check-doc-links` | Same |
-| `freeze_dependencies.py` (both repos) | `tomte freeze-dependencies` | Same |
-| `spell-check.sh` (open-aea) | `tomte check-spelling` | Same |
+| `check_copyright_notice.py` (open-aea) | `tomte check-copyright --author "Valory AG" --author "Fetch.AI Limited" --scan-path ...` | Requires tomte enhancement: multi-author + configurable scan paths |
+| `check_copyright.py` (open-autonomy) | `tomte check-copyright --author "Valory AG" --scan-path ...` | Same enhancement, single author |
+| `check_doc_links.py` (open-autonomy only) | `tomte check-doc-links --url-skips ...` | Already supported via CLI options |
+| `freeze_dependencies.py` (both repos) | `tomte freeze-dependencies --exclude-package open-aea` / `--exclude-package open-autonomy` | Requires tomte enhancement: exclude filter |
+| `spell-check.sh` (open-aea) | `tomte check-spelling` | No changes needed |
 
-**Action:** Update `tox.ini` in both repos to call `tomte <command>` instead of `scripts/<script>.py`, then delete the local copies.
+**Note:** open-aea's `check_doc_links.py` is a fundamentally different tool (validates internal links, images, markdown structure — not just URL availability). It does NOT move to tomte; it moves to `open-aea-ci-helpers` instead.
+
+**Action:** First enhance tomte (multi-author copyright, freeze-deps exclude filter), release new tomte version, then update `tox.ini` in both repos to use tomte.
 
 ### Step 2: Create `open-aea-ci-helpers` plugin
 


### PR DESCRIPTION
## Context

The recent dependent-repo cleanup (optimus, trader, meme-ooorr, IEKit, market-creator) consolidated repo-local scripts into the `aea-helpers` plugin. However, `open-aea` and `open-autonomy` themselves were not part of that effort and still ship ~30 scripts between them, with 7 directly duplicated.

This PR adds a report (`SCRIPTS_CONSOLIDATION_REPORT.md`) at the repo root for review and discussion. It covers:

- Full inventory of all scripts in both repos (what they do, how they're invoked, dependencies)
- Identification of 7 duplicated scripts between the two repos
- Overlap analysis with `tomte` (which already provides some of the same functionality)
- Proposal to create a new `aea-ci-helpers` plugin in `open-aea/plugins/` for generic CI tooling
- Why `aea-helpers` can't be used from `open-aea` (circular dependency via `open-autonomy`)
- Migration plan (4 phases, ~3-4 days estimated effort)
- What stays in `scripts/` after cleanup (release tooling, repo-specific scripts)

**This is a documentation-only PR for review — no code changes.**

Please review the report and provide feedback on the proposed approach before implementation begins.