### PR TITLE
ci: add "All checks passed" aggregate gate job

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -454,3 +454,23 @@ jobs:
       - name: Unit tests
         run: |
           tox --develop -e e2e-py${{ matrix.python-version }}-linux -- -m 'e2e'
+
+  all-checks-passed:
+    name: All checks passed
+    if: always()
+    needs:
+      - lock_check
+      - install_check
+      - copyright_doc_and_dependencies_check
+      - linter_checks
+      - scan
+      - test
+      - e2e
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any dependency did not succeed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "One or more required jobs failed, were cancelled, or were skipped."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a single `all-checks-passed` meta job to `main_workflow.yml` that `needs` every mandatory CI job (`lock_check`, `install_check`, `copyright_doc_and_dependencies_check`, `linter_checks`, `scan`, `test`, `e2e`).
- `if: always()` + explicit fail on any dependency `failure`/`cancelled`/`skipped`, so the aggregate correctly reflects the state of its dependencies.
- Enables branch protection to require a single status context ("All checks passed") instead of enumerating every job — add/remove mandatory jobs by editing the `needs` list in the workflow.

## Test plan
- [ ] CI runs green on this PR and the new `All checks passed` check appears as a status.
- [ ] After merge, update `main` branch protection `required_status_checks.contexts` to `["All checks passed"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)