### PR TITLE
fix: switch release build from setup.py to python -m build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.14"]
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -23,25 +23,22 @@ jobs:
           sudo apt-get update --fix-missing
           sudo apt-get autoremove
           sudo apt-get autoclean
-          python -m pip install --upgrade pip
-          pip install poetry twine
+          python -m pip install --upgrade pip setuptools
+          pip install poetry twine build
           python --version
 
       - name: Build wheels and source tarball
         run: |
           echo Processing open-autonomy
-          poetry install --all-extras --no-interaction
-          poetry run make dist
+          # python -m build performs PEP 517 isolated builds — it does
+          # not need the project's runtime deps, only the `build` package.
+          # Run outside poetry's venv so system-installed `build` is used.
+          make dist
 
-          echo Processing aea-test-autonomy
-          cd plugins/aea-test-autonomy
-          poetry run python setup.py sdist bdist_wheel
-          cd ../..
-
-          echo Processing aea-helpers
-          cd plugins/aea-helpers
-          poetry run python setup.py sdist bdist_wheel
-          cd ../..
+          for plugin in aea-test-autonomy aea-helpers; do
+            echo "Processing $plugin"
+            (cd "plugins/$plugin" && python -m build --sdist --wheel)
+          done
 
       - name: Publish open-autonomy Framework to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -78,8 +75,8 @@ jobs:
         python-version: ["3.14"]
 
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -87,7 +84,7 @@ jobs:
           sudo apt-get update --fix-missing
           sudo apt-get autoremove
           sudo apt-get autoclean
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install .[all] --no-cache
           # Pin Click >=8.3.0: flag_value default handling is broken in <8.3,
           # causing autonomy init --remote --ipfs to ignore the flags.
@@ -105,7 +102,7 @@ jobs:
     needs:
       - publish-autonomy-packages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Docker login
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
@@ -132,7 +129,7 @@ jobs:
     needs:
       - publish-autonomy-packages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Docker login
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
@@ -159,7 +156,7 @@ jobs:
     needs:
       - publish-autonomy-packages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Docker login
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}
@@ -190,7 +187,7 @@ jobs:
     needs:
       - publish-autonomy-packages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Docker login
         env:
           DOCKER_USER: ${{secrets.DOCKER_USER}}

--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,7 @@ eject-contracts:
 
 .PHONY: dist
 dist: clean eject-contracts
-	python setup.py sdist
-	python setup.py bdist_wheel
+	python -m build --sdist --wheel
 
 h := $(shell git rev-parse --abbrev-ref HEAD)
 

--- a/plugins/aea-helpers/pyproject.toml
+++ b/plugins/aea-helpers/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel"]
-build_backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta"

--- a/plugins/aea-test-autonomy/pyproject.toml
+++ b/plugins/aea-test-autonomy/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel"]
-build_backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary

The v0.21.17 release workflow failed on Python 3.14 because `python setup.py sdist bdist_wheel` requires `setuptools`, which is no longer bundled with Python 3.12+.

```
python setup.py sdist
ModuleNotFoundError: No module named 'setuptools'
```

Switches to `python -m build --sdist --wheel` (PEP 517), which reads `[build-system]` from `pyproject.toml` and manages its own build dependencies. This matches how the upstream `open-aea` release workflow already builds.

## Changes

- **`Makefile` `dist` target:** `python setup.py sdist` + `python setup.py bdist_wheel` → `python -m build --sdist --wheel`
- **`release.yml`:** plugin builds now loop with `python -m build` instead of `poetry run python setup.py sdist bdist_wheel`. Added `build` to the `pip install` step.

## Test plan

- [ ] Merge → re-tag v0.21.17 → release workflow succeeds