### PR TITLE
fix: add hidapi build deps to autonomy-user Dockerfile for arm64/armv7

### DIFF
--- a/deployments/Dockerfiles/autonomy-user/Dockerfile
+++ b/deployments/Dockerfiles/autonomy-user/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.14-slim-trixie AS base
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN apt-get update -y && apt-get install gcc git make libssl-dev libffi-dev -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install gcc git make pkg-config libssl-dev libffi-dev libudev-dev libusb-1.0-0-dev -y && rm -rf /var/lib/apt/lists/*
 
 # Install library dependencies into our venv
 RUN python3 -m venv $VIRTUAL_ENV


### PR DESCRIPTION
## Summary

The v0.21.17 release workflow failed at **"Publish User Images"** when building for `linux/arm64` and `linux/arm/v7`:

```
FileNotFoundError: [Errno 2] No such file or directory: 'pkg-config'
ERROR: Failed to build 'hidapi'
```

Failed run: https://github.com/valory-xyz/open-autonomy/actions/runs/24508277674/job/71634390929

## Root cause

`hidapi` is a transitive dependency via:
```
open-autonomy[all] → open-aea-ledger-ethereum-hwi → ledgerwallet==0.1.3 → hidapi
```

**`hidapi 0.15.0` does not ship pre-built wheels for `cp314-aarch64` or `cp314-armv7l`** — only `cp314-x86_64`.

The release workflow builds multi-platform Docker images via `docker buildx --platform linux/amd64,linux/arm64,linux/arm/v7`. On the arm legs, pip falls back to compiling `hidapi` from C source, which requires `pkg-config`, `libudev-dev`, and `libusb-1.0-0-dev`.

### Evidence

**x86_64 wheel exists (build succeeds on amd64):**
```
$ pip download hidapi==0.15.0 --only-binary=:all: --python-version 3.14 --platform manylinux2014_x86_64
Saved hidapi-0.15.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl  ✅
```

**arm64 wheel does NOT exist (source build required):**
```
$ pip download hidapi==0.15.0 --only-binary=:all: --python-version 3.14 --platform manylinux2014_aarch64
ERROR: No matching distribution found for hidapi==0.15.0  ❌
```

**armv7 wheel does NOT exist:**
```
$ pip download hidapi==0.15.0 --only-binary=:all: --python-version 3.14 --platform linux_armv7l
ERROR: No matching distribution found for hidapi==0.15.0  ❌
```

PyPI file listing: https://pypi.org/project/hidapi/0.15.0/#files — confirms only `x86_64` and `win_amd64` wheels for `cp314`.

### Why v0.21.16 passed

The previous release (March 26) resolved `hidapi==0.14.0.post4`, which shipped arm64 wheels for `cp310`–`cp313`:
```
$ pip download hidapi==0.14.0.post4 --only-binary=:all: --python-version 3.10 --platform manylinux2014_aarch64
Saved hidapi-0.14.0.post4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl  ✅
```

Between March 26 and April 16, `hidapi 0.15.0` was released and became the default resolve target. It added `cp314` wheels for x86_64 only, leaving arm platforms without coverage.

## Fix

Add `pkg-config`, `libudev-dev`, and `libusb-1.0-0-dev` to the `apt-get install` line in `deployments/Dockerfiles/autonomy-user/Dockerfile` so `hidapi` source builds succeed on all target architectures.

## Test plan

- [ ] After merge: re-tag v0.21.17 → release workflow's "Publish User Images" job succeeds on all three platforms