### PR TITLE
fix: correct PyPI license classifier + populate long description

### DIFF
--- a/plugins/aea-helpers/README.md
+++ b/plugins/aea-helpers/README.md
@@ -1,0 +1,25 @@
+# open-aea-helpers
+
+CLI helpers for CI and dependency management in AEA / open-autonomy projects. Ships an `aea-helpers` entry point that bundles the scripts previously scattered across individual repos — dependency consistency checks, doc IPFS hash verification, release preparation, agent/service runners, and a few PyInstaller helpers.
+
+## Installation
+
+```bash
+pip install open-aea-helpers
+```
+
+## Usage
+
+```bash
+aea-helpers --help
+```
+
+Common subcommands:
+
+- `aea-helpers check-dependencies` — cross-check package manifest dependencies against tox/pyproject pins
+- `aea-helpers check-doc-hashes` — verify (or `--fix`) IPFS hashes embedded in markdown docs
+- `aea-helpers bump-dependencies` — bump version pins across the repo in one pass
+- `aea-helpers make-release` — release automation
+- `aea-helpers run-agent` / `aea-helpers run-service` — thin wrappers around the `aea` / `autonomy` runners
+
+Intended to be invoked from CI jobs and local pre-release checks, not at agent runtime.

--- a/plugins/aea-helpers/setup.py
+++ b/plugins/aea-helpers/setup.py
@@ -19,8 +19,16 @@
 # ------------------------------------------------------------------------------
 """Setup script for the plug-in."""
 
+from pathlib import Path
+
 from setuptools import find_packages  # type: ignore
 from setuptools import setup  # type: ignore
+
+
+def _read_long_description() -> str:
+    """Read the plugin README as the PyPI long description."""
+    return (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
+
 
 base_deps = [
     # Direct imports: `autonomy.cli.helpers.ipfs_hash`, plus the
@@ -41,7 +49,7 @@ setup(
     author="Valory AG",
     license="Apache-2.0",
     description="CLI helpers for CI and dependency management in AEA-based projects.",
-    long_description="CLI helpers for CI and dependency management in AEA-based projects.",
+    long_description=_read_long_description(),
     long_description_content_type="text/markdown",
     packages=find_packages(where=".", include=["aea_helpers", "aea_helpers.*"]),
     package_data={

--- a/plugins/aea-test-autonomy/setup.py
+++ b/plugins/aea-test-autonomy/setup.py
@@ -19,8 +19,16 @@
 # ------------------------------------------------------------------------------
 """Setup script for the plug-in."""
 
+from pathlib import Path
+
 from setuptools import find_packages  # type: ignore
 from setuptools import setup  # type: ignore
+
+
+def _read_long_description() -> str:
+    """Read the plugin README as the PyPI long description."""
+    return (Path(__file__).parent / "README.md").read_text(encoding="utf-8")
+
 
 base_deps = [
     # `open-autonomy[all,docker]` supplies everything the plugin's
@@ -39,7 +47,7 @@ setup(
     author="Valory AG",
     license="Apache-2.0",
     description="Plugin containing test tools for open-autonomy packages.",
-    long_description="Plugin containing test tools for open-autonomy packages.",
+    long_description=_read_long_description(),
     long_description_content_type="text/markdown",
     packages=find_packages(
         where=".", include=["aea_test_autonomy", "aea_test_autonomy.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "open-autonomy"
 version = "0.21.18"
 description = "Open Autonomy Framework"
 authors = ["developer-valory <develope@valory.xyz>"]
-license = "Apache-2.0 license"
+license = "Apache-2.0"
+readme = "README.md"
 packages = [{include = "autonomy"}, {include = "packages"}]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## Summary

Two PyPI-metadata bugs in the `0.21.18` release and its plugins, both caused by how `pyproject.toml` / `setup.py` were filled out — not by anything in the code itself. Fixes mirror what already shipped in open-aea ([commit `407946726`](https://github.com/valory-xyz/open-aea/commit/407946726)).

### 1. License classifier fell back to "Other/Proprietary"

Root `pyproject.toml` had:

```toml
license = "Apache-2.0 license"
```

Poetry's build backend can't map the string `"Apache-2.0 license"` to a known SPDX identifier (trailing word "license" breaks the trove-classifier lookup), so the wheel shipped with:

```
License: Apache-2.0 license
License :: Other/Proprietary License    ← the bogus classifier
```

This is why every downstream consumer that runs `liccheck` against `open-autonomy==0.21.18` has to carry a workaround `open-autonomy: ==0.21.18` entry under `[Authorized Packages]` — surfaced in kv-store/genai/funds-manager/mech/mech-server PRs.

Fix: drop the trailing word, so Poetry resolves it to `License :: OSI Approved :: Apache Software License`.

### 2. PyPI description pages were empty / one-liners

- Root `pyproject.toml` didn't declare a `readme`, so Poetry emitted no `Description` body in the root wheel — pypi.org/project/open-autonomy was blank below the one-line summary.
- Both plugin `setup.py` files hardcoded `long_description` to the same text as `description`, so their PyPI pages also shipped minimal descriptions.

Fix (uniform):
- Root: add `readme = "README.md"` to `[tool.poetry]`.
- `plugins/aea-test-autonomy/setup.py`: small `_read_long_description()` helper that reads the plugin's README and wires it through to `long_description`. README already existed.
- `plugins/aea-helpers`: add a `README.md` describing the CLI (subcommands, install), then same setup.py helper pattern.

## Verification

Rebuilt all three wheels locally after the change. Before vs. after:

| Package | License (before) | License (after) | Description length (before → after) |
|---|---|---|---|
| `open-autonomy` | `Apache-2.0 license` + `Other/Proprietary` classifier | `Apache-2.0` + `Apache Software License` classifier | 0 → 4864 |
| `open-aea-helpers` | `Apache-2.0` (ok) | `Apache-2.0` (ok) | 68 → 990 |
| `open-aea-test-autonomy` | `Apache-2.0` (ok) | `Apache-2.0` (ok) | 57 → 181 |

All wheels now report `Description-Content-Type: text/markdown` and their README bodies as the PyPI long description.

## Caveat

PyPI does not allow re-uploading the same version, so `0.21.18` on pypi.org will remain empty / mis-classified regardless of this PR. The fix applies starting with the next release (`0.21.19`). Once that's cut, the downstream liccheck workaround (`open-autonomy: ==0.21.18` under `[Authorized Packages]`) can be removed from consumer repos.

## Test plan

- [x] `poetry check --lock`
- [x] `poetry install --all-extras`
- [x] `tomte format-copyright`
- [x] `tox -e liccheck`
- [x] `tox -e check-api-docs`
- [x] `tox -e check-doc-links-hashes`
- [x] `tox -e check-dependencies`
- [x] `tox -e check-third-party-hashes`
- [x] `tox -e check-packages`
- [x] `tox -e check-hash`
- [x] `tox -e bandit` + `tox -e safety`
- [x] `tox -e black-check` / `isort-check` / `flake8`
- [x] `tox -e mypy` / `pylint` / `darglint`
- [x] `tox -e spell-check`
- [x] `tox -e check-abci-docstrings` / `check-abciapp-specs` / `check-handlers` / `check-dialogues`
- [x] `tox -e check-copyright`
- [x] Rebuilt all three wheels and verified `License`, `Classifier`, and `Description` fields in `METADATA`

> `tox -e check-generate-all-protocols` fails locally because my host has `protoc 29.2` while the tool pins `24.3`; CI has the correct pin. Confirmed unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)