### PR TITLE
docs: remove price-oracle and IEKit references

### DIFF
--- a/docs/advanced_reference/developer_tooling/debugging_in_the_cluster.md
+++ b/docs/advanced_reference/developer_tooling/debugging_in_the_cluster.md
@@ -4,8 +4,8 @@
 When debugging deployments, it can be useful to have the option to spin up a hardhat node to enable debugging and testing of the issue within the cluster. First, fetch the AI agent:
 
 ```bash
-autonomy fetch valory/oracle_hardhat --local --service
-cd oracle_hardhat
+autonomy fetch valory/hello_world --local --service
+cd hello_world
 ```
 
 You now need to replace the override in the ```service.yaml``` file: change ```http://host.docker.internal:8545``` to ```http://hardhat:8545```.

--- a/docs/advanced_reference/developer_tooling/dev_mode.md
+++ b/docs/advanced_reference/developer_tooling/dev_mode.md
@@ -10,10 +10,10 @@ Before starting this guide, ensure that your machine satisfies the framework req
 
 ## Build and run an AI agent in `dev` mode
 
-1. **Fetch the AI agent.** Fetch the Price Oracle AI agent from the remote registry.
+1. **Fetch the AI agent.** Fetch the Hello World AI agent from the remote registry.
 
     ```bash
-    autonomy fetch valory/oracle_hardhat:0.1.0:<hash> --service
+    autonomy fetch valory/hello_world:0.1.0:<hash> --service
     ```
 
 2. **Build the deployment.** Within the AI agent folder, execute the command below to build the AI agent deployment in `dev` mode, including a pre-configured Hardhat instance.

--- a/docs/application_deployment.md
+++ b/docs/application_deployment.md
@@ -57,10 +57,10 @@ Options:
 
 ```
 
-For example, in order to build a deployment from scratch for oracle abci, first ensure you have a clean build environment and then build the images:
+For example, in order to build a deployment from scratch, first ensure you have a clean build environment and then build the images:
 ```bash
 rm -rf abci_build_*
-autonomy build-image valory/oracle_hardhat
+autonomy build-image valory/hello_world
 ```
 
 Next, run the command to generate the relevant build configuration:

--- a/docs/key_concepts/fsm_app_introduction.md
+++ b/docs/key_concepts/fsm_app_introduction.md
@@ -43,7 +43,7 @@ Due to the variety of FSMs that can be defined, the framework does not enforce t
     observations to a temporary blockchain), or a voting round (e.g.,
     waiting until at least an observed value has reached $\lceil(2N + 1) / 3\rceil$ of the votes).
 
-    The developer could define the concept of "period" for their FSM as the sequence of stages in the FSM state flow that achieve a specific objective defined by the {{fsm_app}}. Consider the price oracle demo, which aggregates asset prices from different data sources and submits the aggregated result to an L1/L2 blockchain. In this example, the developer could define a period as follows:
+    The developer could define the concept of "period" for their FSM as the sequence of stages in the FSM state flow that achieve a specific objective defined by the {{fsm_app}}. For example, consider an AI agent that aggregates observations from different data sources and submits the aggregated result to an L1/L2 blockchain. In this example, the developer could define a period as follows:
 
     1. Collect observations from external APIs or prior rounds.
     2. Reach consensus on the set of collected observations (i.e., 2/3 of the agent instances must agree).

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -116,7 +116,7 @@ If your CI invokes any of these scripts directly, update to the corresponding CL
     - `aea-helpers run-agent --name <agent>` — replaces `run_agent.sh` with built-in port management (`--free-ports`), config replacement, and tendermint lifecycle
     - `aea-helpers run-service --name <service>` — replaces `run_service.sh` with parameterized deployment (agent count, resource limits, pre/post hooks)
     - `aea-helpers make-release --version <ver> --env <env>` — replaces `make_release.sh` for creating git tags and GitHub releases
-- New `--skip-tendermint` flag on `run-agent` for agents configured with `use_tendermint: false` (e.g. IEKit)
+- New `--skip-tendermint` flag on `run-agent` for agents configured with `use_tendermint: false`
 - Fixes `customs` package type handling in `check-doc-hashes` (no longer crashes on mech tool packages)
 - Fixes IPFS connection handler to support directories and binary files
 - To migrate deployment scripts: extract your `PATH_TO_VAR` dict from `aea-config-replace.py` into a `config-mapping.json` file, then delete `aea-config-replace.py`, `run_agent.sh`, and `run_service.sh`


### PR DESCRIPTION
## Summary

The [Olas Stack docs](https://github.com/valory-xyz/docs) just dropped the price-oracle demo and the IEKit toolkit (valory-xyz/docs#162). This PR cleans up the matching references that are surfaced on the published site via this repo's `mkdocs.yml`.

- **`docs/advanced_reference/developer_tooling/dev_mode.md`** — swap the `oracle_hardhat` fetch command for `hello_world` (the dev-mode tutorial is otherwise agent-agnostic)
- **`docs/advanced_reference/developer_tooling/debugging_in_the_cluster.md`** — same swap in the cluster-debugging guide (page already carries an "under review" banner)
- **`docs/application_deployment.md`** — same swap; drop the "for oracle abci" framing
- **`docs/key_concepts/fsm_app_introduction.md`** — drop the named reference to the price oracle demo in the "period" example's opening sentence; keep the generic aggregator-pattern description and the 7-step example intact
- **`docs/upgrading.md`** — drop the `(e.g. IEKit)` parenthetical from the `--skip-tendermint` changelog entry

No content deleted wholesale — every page still makes sense. `HISTORY.md` references are intentionally left alone (historical changelog).

## Test plan

- [x] Built the full Olas Stack docs site in strict mode (`tox -e docs` from the parent `valory-xyz/docs` repo against this branch) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)