### PR TITLE
Surface named env-var placeholders from service overrides

### DIFF
--- a/autonomy/configurations/base.py
+++ b/autonomy/configurations/base.py
@@ -47,7 +47,11 @@ from aea.configurations.data_types import (
 )
 from aea.exceptions import AEAValidationError
 from aea.helpers.base import SimpleIdOrStr
-from aea.helpers.env_vars import apply_env_variables, generate_env_vars_recursively
+from aea.helpers.env_vars import (
+    ENV_VARIABLE_RE,
+    apply_env_variables,
+    generate_env_vars_recursively,
+)
 
 from autonomy.configurations.constants import DEFAULT_SERVICE_CONFIG_FILE, SCHEMAS_DIR
 from autonomy.configurations.validation import ConfigValidator
@@ -291,6 +295,8 @@ class Service(PackageConfiguration):  # pylint: disable=too-many-instance-attrib
                 raise ValueError(
                     f"Overrides not provided for agent {agent_idx}; component={component_id}"
                 )
+        named_env_vars = self._extract_named_env_var_defaults(configuration)
+
         configuration = apply_env_variables(
             data=configuration, env_variables=os.environ.copy()
         )
@@ -298,8 +304,39 @@ class Service(PackageConfiguration):  # pylint: disable=too-many-instance-attrib
             component_id=component_id,
             component_configuration_json=configuration,
         )
+        for name, default in named_env_vars.items():
+            env_var_dict.setdefault(name, default)
 
         return env_var_dict
+
+    @staticmethod
+    def _extract_named_env_var_defaults(data: Any) -> Dict[str, Any]:
+        """Collect ``{NAME: default}`` for every ``${NAME:type:default}`` placeholder.
+
+        Path-keyed entries built later by :func:`generate_env_vars_recursively`
+        only let downstream callers override values via the path key. Surfacing
+        the placeholder's own name lets the user override by that name too,
+        which matches how the names are declared in ``service.yaml``.
+
+        :param data: raw component configuration (must be inspected before
+            ``apply_env_variables`` substitutes the placeholders away).
+        :return: mapping of placeholder var name to its inline default
+            (``None`` when the placeholder declared no default).
+        """
+        result: Dict[str, Any] = {}
+        if isinstance(data, dict):
+            for value in data.values():
+                result.update(Service._extract_named_env_var_defaults(value))
+        elif isinstance(data, (list, tuple)):
+            for value in data:
+                result.update(Service._extract_named_env_var_defaults(value))
+        elif isinstance(data, str):
+            match = ENV_VARIABLE_RE.match(data)
+            if match is not None:
+                _, var_name, _, _, default = match.groups()
+                if var_name is not None:
+                    result[var_name] = default
+        return result
 
     @staticmethod
     def generate_environment_variables(

--- a/autonomy/configurations/base.py
+++ b/autonomy/configurations/base.py
@@ -305,7 +305,7 @@ class Service(PackageConfiguration):  # pylint: disable=too-many-instance-attrib
             component_configuration_json=configuration,
         )
         for name, default in named_env_vars.items():
-            env_var_dict.setdefault(name, default)
+            env_var_dict.setdefault(name, os.environ.get(name, default))
 
         return env_var_dict
 

--- a/tests/test_autonomy/test_cli/test_deploy/test_build/test_deployment.py
+++ b/tests/test_autonomy/test_cli/test_deploy/test_build/test_deployment.py
@@ -305,6 +305,7 @@ class BaseDeployBuildTest(BaseCliTest):
                 "CONNECTION_LEDGER_CONFIG_LEDGER_APIS_ETHEREUM_DEFAULT_GAS_PRICE_STRATEGY": "eip1559",
                 "CONNECTION_ABCI_CONFIG_HOST": "localhost",
                 "CONNECTION_ABCI_CONFIG_PORT": "26658",
+                "SERVICE_REGISTER_RESET_RPC": "http://host.docker.internal:8545",
             }
 
     @staticmethod

--- a/tests/test_autonomy/test_configurations.py
+++ b/tests/test_autonomy/test_configurations.py
@@ -25,6 +25,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from typing import Dict, List
+from unittest import mock
 
 import pytest
 import yaml
@@ -254,6 +255,40 @@ class TestServiceConfig:
         assert env_vars["SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_NAMED"] == "foo"
         assert env_vars["SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_ANON"] == "bar"
         assert "ANON" not in env_vars
+
+    def test_named_placeholder_prefers_os_environ_over_inline_default(
+        self,
+    ) -> None:
+        """``os.environ`` should win over the inline placeholder default.
+
+        Path-keyed entries already pick up the ``os.environ`` value via
+        ``apply_env_variables``; the named entry must follow the same
+        precedence so the two stay in sync.
+        """
+
+        service = Service(name="service", author="author", agent="valory/agent")
+        component = {
+            "type": "skill",
+            "public_id": "valory/dummy_skill:0.1.0",
+            "models": {
+                "params": {
+                    "args": {
+                        "endpoint": "${SERVICE_RPC:str:http://default:8545}",
+                    }
+                }
+            },
+        }
+
+        with mock.patch.dict(
+            os.environ, {"SERVICE_RPC": "https://override.example/rpc"}, clear=False
+        ):
+            env_vars = service.process_component_overrides(0, component)
+
+        assert env_vars["SERVICE_RPC"] == "https://override.example/rpc"
+        assert (
+            env_vars["SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_ENDPOINT"]
+            == "https://override.example/rpc"
+        )
 
     def teardown_method(
         self,

--- a/tests/test_autonomy/test_configurations.py
+++ b/tests/test_autonomy/test_configurations.py
@@ -180,6 +180,81 @@ class TestServiceConfig:
         connection_override = service.overrides[0]
         assert connection_override["is_abstract"] == "${DISABLE_CONNECTION:bool:true}"
 
+    def test_named_env_var_placeholders_are_emitted(
+        self,
+    ) -> None:
+        """Named placeholders should produce ``{NAME: default}`` entries."""
+
+        service = Service(name="service", author="author", agent="valory/agent")
+        component = {
+            "type": "skill",
+            "public_id": "valory/dummy_skill:0.1.0",
+            "models": {
+                "params": {
+                    "args": {
+                        "message": "${HELLO_WORLD_MESSAGE:str:hi}",
+                    }
+                }
+            },
+        }
+
+        env_vars = service.process_component_overrides(0, component)
+
+        assert env_vars["HELLO_WORLD_MESSAGE"] == "hi"
+        assert (
+            env_vars["SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_MESSAGE"] == "hi"
+        ), "path-keyed entry must still be produced"
+
+    def test_anonymous_placeholders_emit_only_path_keys(
+        self,
+    ) -> None:
+        """Anonymous ``${type:default}`` placeholders should not add named keys."""
+
+        service = Service(name="service", author="author", agent="valory/agent")
+        component = {
+            "type": "skill",
+            "public_id": "valory/dummy_skill:0.1.0",
+            "models": {
+                "params": {
+                    "args": {
+                        "message": "${str:hi}",
+                    }
+                }
+            },
+        }
+
+        env_vars = service.process_component_overrides(0, component)
+
+        assert env_vars == {
+            "SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_MESSAGE": "hi",
+        }
+
+    def test_named_and_anonymous_placeholders_coexist(
+        self,
+    ) -> None:
+        """A mix of named and anonymous placeholders should both be surfaced."""
+
+        service = Service(name="service", author="author", agent="valory/agent")
+        component = {
+            "type": "skill",
+            "public_id": "valory/dummy_skill:0.1.0",
+            "models": {
+                "params": {
+                    "args": {
+                        "named": "${MY_NAMED:str:foo}",
+                        "anon": "${str:bar}",
+                    }
+                }
+            },
+        }
+
+        env_vars = service.process_component_overrides(0, component)
+
+        assert env_vars["MY_NAMED"] == "foo"
+        assert env_vars["SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_NAMED"] == "foo"
+        assert env_vars["SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_ANON"] == "bar"
+        assert "ANON" not in env_vars
+
     def teardown_method(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- `Service.process_component_overrides` previously emitted env-var entries keyed only by the YAML traversal path (e.g. `SKILL_DUMMY_SKILL_MODELS_PARAMS_ARGS_MESSAGE`). Named placeholders like `${HELLO_WORLD_MESSAGE:str:hi}` left no `HELLO_WORLD_MESSAGE` entry in the agent's env dict, so downstream callers (e.g. middleware injecting from `service.yaml`) could not override values by their declared name.
- Added `Service._extract_named_env_var_defaults`, a parallel walk over the raw override config (run *before* `apply_env_variables` substitutes the placeholders away) that collects `{NAME: default}` for every `${NAME:type:default}` placeholder. The collected entries are merged with `setdefault` so existing path-keyed entries always win on conflict.
- Path-based env-var output is unchanged. For mixed configs, both keys are emitted side-by-side.

## Why

The prior behavior meant named env vars declared in `service.yaml` were silently dropped from the generated agent env. Middleware workarounds had to inject them manually based on the service template, which only covered template-declared names — anything added directly in `service.yaml` was missed.

## Test plan

- [x] `tests/test_autonomy/test_configurations.py` — three new cases (`test_named_env_var_placeholders_are_emitted`, `test_anonymous_placeholders_emit_only_path_keys`, `test_named_and_anonymous_placeholders_coexist`) covering named-only, anonymous-only, and mixed placeholders. All 16 tests in the file pass.
- [x] `tests/test_autonomy/test_deploy/test_service_specification.py` — 21 existing service-builder tests still pass.
- [x] Local lint: black-check, isort-check, flake8, mypy, pylint (10/10), bandit, safety, vulture, liccheck all green.

## Notes

- `check-packages` / `check-hash` / `check-dependencies` fail locally on `connection/valory/ledger:0.19.0` due to pre-existing main-branch hash drift unrelated to this PR (no `packages/` files touched here).
- Marking draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)