### PR TITLE
chore(claude-skills): cover gaps from trader/optimus/meme-ooorr audits

### DIFF
--- a/claude-skills/audit-fsm/SKILL.md
+++ b/claude-skills/audit-fsm/SKILL.md
@@ -377,13 +377,14 @@ Different agents may have different files → different events → consensus bre
 
 **Severity by service shape:**
 - **Multi-agent service:** Critical — consensus break.
-- **Single-agent / sovereign service** (e.g. some Pearl-shipped configurations): demote to **informational** but still surface — the bug appears the moment the service is promoted to multi-agent.
+- **Single-agent / sovereign service** (e.g. some Pearl-shipped configurations): demote to **Low (L)** with a note: *"severity escalates to Critical when the service runs with N>1 agents."* This keeps the finding in the standard L section of the report rather than vanishing — Pearl-shipped services regularly get promoted to multi-agent, so silent loss is the worst outcome.
 
 **How to check:**
 1. Walk every `end_block()` body and any function it calls.
-2. Grep the imports of the round module for `time`, `datetime`, `random`, `os`, `requests`, `urllib`, `pathlib`.
-3. For each non-deterministic call found, verify whether the surrounding code path can reach `end_block()`.
-4. Check whether the agent's service config (look at `services/*/service.yaml` `number_of_agents`) is 1 or N to set severity.
+2. **Also walk every `process_payload()` body in the same round.** `process_payload()` populates `self.synchronized_data` / round-local state that `end_block()` then reads — non-deterministic writes in `process_payload()` produce non-deterministic `end_block()` reads even when the `end_block()` body itself is clean. An auditor who walks only `end_block()` will report a clean C5 on a real consensus break.
+3. Grep the imports of the round module for `time`, `datetime`, `random`, `os`, `requests`, `urllib`, `pathlib`.
+4. For each non-deterministic call found, verify whether the surrounding code path can reach `end_block()` (directly or via `process_payload()` → `synchronized_data` propagation).
+5. Check whether the agent's service config (look at `services/*/service.yaml` `number_of_agents`) is 1 or N to set severity.
 
 **Fix:** All non-deterministic data must be sourced from `synchronized_data` — i.e. agreed via consensus by the predecessor round's payload.
 
@@ -561,11 +562,16 @@ Plus: when a `SynchronizedData` subclass uses **multiple inheritance** to combin
 
 **Bug examples:**
 ```python
-# BUG: set is not JSON-serializable — TypeError at write time
+# BUG (write-time crash): set is not JSON-serializable — TypeError at write time
 self.synchronized_data.update(participants={agent1, agent2})
 
-# BUG: Decimal becomes float after JSON round-trip — silent precision loss
+# BUG (write-time crash): Decimal is not JSON-serializable — TypeError at write time
+# (same failure mode as set; do NOT mistake this for silent rounding to float)
 self.synchronized_data.update(price=Decimal("0.123456789012345678"))
+
+# BUG (silent precision loss): float arithmetic drifts BEFORE serialization;
+# JSON round-trip then preserves the wrong value
+self.synchronized_data.update(price=0.1 + 0.2)  # writes 0.30000000000000004
 
 # BUG: same property name in two parents
 class MechInteractSyncedData:
@@ -585,9 +591,9 @@ class SynchronizedData(MechInteractSyncedData, MarketManagerSyncedData):
 **What:** After a period reset (`ResetAndPauseRound`), the next period restarts at the chain's initial round. Any DB key that the initial round chain (or its behaviours) reads via `self.db.get` / `self.db.get_strict` must be in `cross_period_persisted_keys` — otherwise it's missing after the first reset and the read returns `None` / raises `KeyError`. The bug is invisible in the first period (the key was just written) and surfaces only after the reset.
 
 **How to check:**
-1. Identify the initial round chain after a reset (typically `RegistrationRound` → ... → first business round). Use the composed app's `transition_function` to follow `Event.RESET_TIMEOUT` / `Event.DONE` from `ResetAndPauseRound` to the next round.
+1. Identify the initial round chain after a reset (typically `RegistrationRound` → ... → first business round). Use the composed app's `transition_function` to follow **`Event.DONE`** from `ResetAndPauseRound` to the next round — this is the normal post-reset re-entry path. `Event.RESET_AND_PAUSE_TIMEOUT` and `Event.NO_MAJORITY` are failure paths that route to `FinishedResetAndPauseErrorRound` and do not represent the post-reset initial-read set (see `packages/valory/skills/reset_pause_abci/rounds.py:94-98`). Tracing the failure path will surface bogus keys or miss the real ones.
 2. Statically collect every `self.db.get(...)` / `self.db.get_strict(...)` and every `self.synchronized_data.<property>` access in those rounds and their behaviours. Resolve property accesses to the underlying DB key.
-3. Subtract `cross_period_persisted_keys`. The diff is the set of keys that will be missing after the first reset.
+3. Subtract `cross_period_persisted_keys` **AND `AbciAppDB.default_cross_period_keys`**. The framework auto-injects the defaults at every period boundary (`packages/valory/skills/abstract_round_abci/base.py:516-523` then `:549`); a skill that reads any of `{all_participants, participants, consensus_threshold, safe_contract_address}` after a reset does NOT need to redeclare them — they survive every period automatically. Subtracting only `cross_period_persisted_keys` produces false positives on every audit. The remaining diff is the set of keys that will genuinely be missing after the first reset.
 
 **Why it matters:** First-period success masks the bug. Production crashes appear only after the first natural reset (often hours or days into a deployment).
 

--- a/claude-skills/audit-fsm/SKILL.md
+++ b/claude-skills/audit-fsm/SKILL.md
@@ -176,6 +176,24 @@ Downstream projects compose these library skills with their own custom skills vi
 
 **Audit implication:** Do NOT flag `ROUND_TIMEOUT` (or other standard event names) as M2 findings in library skills when the enum member exists but isn't used in the skill's own transition function. This is a convention, not dead code.
 
+**Project-specific library skills.** The list above is the *framework default*. Downstream projects often introduce their own library skills (skills meant to be composed only). When auditing a downstream repo:
+
+- Skills with `is_abstract: true` in `skill.yaml` are typically library skills.
+- Check the project's `CLAUDE.md` / `AGENTS.md` for an explicit library-skills list.
+- Read `aea-config.yaml` of the agent under audit — skills that appear only as composition imports (and are never directly wired to the FSM by the agent) are library skills.
+- Apply the M2 / C4 carve-outs to those project-specific library skills as well.
+
+### `is_abstract: true` Semantics
+
+A skill with `is_abstract: true` in its `skill.yaml` is composition-only — it is never instantiated as a top-level skill, only consumed by another `chain()` call. Audit checks branch on this flag:
+
+- **Skip** "missing `fsm_specification.yaml`" findings — abstract skills are composed-only and don't need standalone wiring.
+- **Skip** "missing dialogue X" findings if the dialogue is provided by the composing skill.
+- **Demote** "missing handler" findings to informational unless the handler is required for composition (e.g. an `ABCIHandler` is mandatory).
+- **Apply** the same M2 / C4 carve-outs as library skills (unused events / dead timeouts may be intentional extension points).
+
+The `agent_performance` "missing dialogues" / "missing fsm_specification" findings from prior audits worked out only because the CLI tool happened to fail. With the `is_abstract` branch, those findings are correctly suppressed at the source.
+
 ### Test Infrastructure
 
 The framework provides base test classes in `packages/valory/skills/abstract_round_abci/test_tools/` and `plugins/aea-test-autonomy/`.
@@ -316,6 +334,8 @@ if (
 2. Verify each such event appears in the round's entry in `transition_function`
 3. For rounds extending `CollectSameUntilThresholdRound` etc., check that `done_event`, `none_event`, `no_majority_event` (and `fail_event` for keeper rounds) are all wired in the transition function
 
+**Carve-out — framework-scheduled events:** Events scheduled by the framework via `event_to_timeout` (most commonly `ROUND_TIMEOUT`) are NOT emitted by `end_block()` — the framework dispatches them via Tendermint's `update_time()`. An event is `end_block`-emittable only if it is part of the round's base class event set (`done_event`, `none_event`, `no_majority_event`, `fail_event`) or returned explicitly by a custom `end_block` override. Do NOT flag a transition-function event as "missing from `end_block()`" if it is wired into `event_to_timeout` — that is the framework's job.
+
 **Why it matters:** A missing transition means the round never completes, hanging the entire agent service.
 
 #### C4: Dead Timeouts
@@ -330,6 +350,42 @@ if (
 **Why it matters:** Developers may believe a timeout is protecting against hangs, when in fact it never fires. This creates a false sense of safety.
 
 **Caveat:** Skills whose directory name starts with `test_` (e.g. `test_abci`, `test_solana_tx_abci`) are **test/scaffold skills** that exist to exercise the framework, not production FSM apps. Dead timeouts in these skills are often intentional test fixtures (e.g. testing that `SharedState.setup()` can wire `event_to_timeout` from params). Do NOT flag these as C4 findings. See also the False Positive Guidance section.
+
+#### C5: Non-Determinism in `end_block()`
+
+**What:** `AbstractRound.end_block()` must be a **pure function of consensus state**. Reading wall-clock time, the file system, environment variables, randomness, or external services produces a different event on different agents — silently breaking consensus. The Tendermint replica picks one of the divergent state transitions; the others are wedged or marked Byzantine.
+
+**Search patterns inside `end_block()` bodies (and any helper called from `end_block`):**
+- File I/O: `open(`, `Path.read_*`, `json.load(open(`, `os.path.exists(`, `pathlib.*`
+- Wall clock: `time.time()`, `datetime.now()`, `datetime.utcnow()`, `time.monotonic()` — use `synchronized_data.last_round_transition_timestamp` instead (set by the framework from agreed block time)
+- Randomness: `random.*`, `secrets.*`, `os.urandom(` — use `synchronized_data.most_voted_randomness` (consensus randomness)
+- Environment: `os.environ.get(`, `os.getenv(`
+- Network / external services: `requests.*`, `urlopen(`, `socket.*`, `subprocess.*`, contract calls, IPFS reads
+- Locale-dependent operations: `locale.*`, `re` patterns that depend on system locale
+
+**Bug example:**
+```python
+def end_block(self) -> Optional[Tuple[BaseSynchronizedData, Enum]]:
+    # BUG: each agent reads its own local file
+    with open("/tmp/benchmark_mode.json") as f:
+        config = json.load(f)
+    if config["mode"] == "benchmark":
+        return self.synchronized_data, Event.BENCHMARK
+    return self.synchronized_data, Event.NORMAL
+```
+Different agents may have different files → different events → consensus break.
+
+**Severity by service shape:**
+- **Multi-agent service:** Critical — consensus break.
+- **Single-agent / sovereign service** (e.g. some Pearl-shipped configurations): demote to **informational** but still surface — the bug appears the moment the service is promoted to multi-agent.
+
+**How to check:**
+1. Walk every `end_block()` body and any function it calls.
+2. Grep the imports of the round module for `time`, `datetime`, `random`, `os`, `requests`, `urllib`, `pathlib`.
+3. For each non-deterministic call found, verify whether the surrounding code path can reach `end_block()`.
+4. Check whether the agent's service config (look at `services/*/service.yaml` `number_of_agents`) is 1 or N to set severity.
+
+**Fix:** All non-deterministic data must be sourced from `synchronized_data` — i.e. agreed via consensus by the predecessor round's payload.
 
 ### High (H) — Issues with significant impact
 
@@ -422,6 +478,62 @@ class SynchronizedData(BaseSynchronizedData):
 ```
 
 **Why it matters:** The property silently returns data from a different round, causing logic errors or `KeyError` crashes.
+
+#### M6: SynchronizedData JSON Round-Trip Safety
+
+**What:** Writes to `synchronized_data` go through `AbciAppDB.update()` which JSON-serializes values. Values that are not JSON-native (`set`, `Decimal`, `dataclass` instances, `datetime`, `tuple` of mixed types, custom enum members) silently lose fidelity (e.g. `tuple` → `list`) or raise `TypeError` at write time. Custom serializer hooks (e.g. `EGreedyPolicy.serialize` / `deserialize`) must be applied symmetrically on the read side.
+
+Plus: when a `SynchronizedData` subclass uses **multiple inheritance** to combine data classes from composed skills (e.g. `class SynchronizedData(MechInteractSyncedData, MarketManagerSyncedData, TxSettlementSyncedData)`), two parents defining the same property name silently shadow according to MRO order. The subclass author may believe they are reading from skill A's data when they're actually reading from skill B's.
+
+**How to check:**
+1. For each round's `end_block()`, list keys + value-expressions written via `update(...)` or `update(synchronized_data_class=..., ...)`.
+2. For each value, infer the type (walk back from the call site, or look at the payload field type, or trace through `json.loads`). Flag values that are not JSON-native unless a custom serializer is documented at both write and read sides.
+3. For each `SynchronizedData` subclass with multiple base classes, walk the MRO and flag any property name defined in more than one parent — explicitly call out which parent wins.
+
+**Bug examples:**
+```python
+# BUG: set is not JSON-serializable — TypeError at write time
+self.synchronized_data.update(participants={agent1, agent2})
+
+# BUG: Decimal becomes float after JSON round-trip — silent precision loss
+self.synchronized_data.update(price=Decimal("0.123456789012345678"))
+
+# BUG: same property name in two parents
+class MechInteractSyncedData:
+    @property
+    def latest_event(self) -> str: return self.db.get_strict("mech_event")
+class MarketManagerSyncedData:
+    @property
+    def latest_event(self) -> str: return self.db.get_strict("market_event")
+class SynchronizedData(MechInteractSyncedData, MarketManagerSyncedData):
+    pass  # reads mech_event — likely surprising for someone reading the file top-down
+```
+
+**Fix:** Use lists/dicts/primitives or apply explicit serialize/deserialize hooks. Pick distinct property names across composed data classes, or override explicitly with documented intent.
+
+#### M7: `cross_period_persisted_keys` Completeness for Post-Reset Initial Reads
+
+**What:** After a period reset (`ResetAndPauseRound`), the next period restarts at the chain's initial round. Any DB key that the initial round chain (or its behaviours) reads via `self.db.get` / `self.db.get_strict` must be in `cross_period_persisted_keys` — otherwise it's missing after the first reset and the read returns `None` / raises `KeyError`. The bug is invisible in the first period (the key was just written) and surfaces only after the reset.
+
+**How to check:**
+1. Identify the initial round chain after a reset (typically `RegistrationRound` → ... → first business round). Use the composed app's `transition_function` to follow `Event.RESET_TIMEOUT` / `Event.DONE` from `ResetAndPauseRound` to the next round.
+2. Statically collect every `self.db.get(...)` / `self.db.get_strict(...)` and every `self.synchronized_data.<property>` access in those rounds and their behaviours. Resolve property accesses to the underlying DB key.
+3. Subtract `cross_period_persisted_keys`. The diff is the set of keys that will be missing after the first reset.
+
+**Why it matters:** First-period success masks the bug. Production crashes appear only after the first natural reset (often hours or days into a deployment).
+
+#### M8: Misleading Event-Shaped Class Attributes on Round Subclasses
+
+**What:** On `CollectSameUntilThresholdRound` and siblings, the framework's `end_block()` consults a fixed set of class attributes: `done_event`, `none_event`, `no_majority_event`, `collection_key`, `selection_key` (and `fail_event` for keeper rounds — see `extended_requirements`). Defining additional class attributes whose RHS is an `Event` enum value (e.g. `withdrawal_initiated: Event = Event.WITHDRAWAL_INITIATED`) does NOT wire that event into the round — the parent's `end_block()` never reads it.
+
+Combined with a `transition_function` entry for that event, this produces a "looks-like-config-but-isn't" footgun. The current C3 check catches the dead transition. M8 catches the misleading attribute that gives the false impression the round will emit it.
+
+**How to check:**
+1. For each `CollectSameUntilThresholdRound` (or sibling) subclass, list class-level attributes whose RHS is an `Event` enum value.
+2. Subtract the names actually consulted by the parent class (`done_event`, `none_event`, `no_majority_event`, `fail_event`, `collection_key`, `selection_key`) and any name read by a custom `end_block` override in the subclass.
+3. The remainder is dead config. Suggested fix: either implement a custom `end_block()` that uses the attribute, or remove it.
+
+**Why it matters:** Combined with a wired transition, the dead attribute makes a reader assume mid-round side transitions exist (e.g. "withdrawal can interrupt this round") when they don't — leading to design decisions based on capabilities the FSM doesn't actually have.
 
 ### Test (T) — Test correctness and coverage
 
@@ -539,6 +651,46 @@ self.end_round(done_event)         # Transition to next round
 
 **What:** Comments or docstrings describing the FSM that don't match the actual `transition_function` definition.
 
+#### L4: Logging Hygiene (Secret / PII Leakage)
+
+**What:** Behaviour and connection log lines that interpolate variables holding credentials, signed material, or full HTTP responses expose secrets to log aggregators and on-disk logs. Once a secret is in a log stream, it must be assumed compromised.
+
+**Search patterns:**
+- Variable name regex inside `logger.*(f"... {x} ..."`, `logger.*("... %s ...", x)`, `logger.*("... " + x)`:
+  - `private_key`, `priv_key`, `pk`, `sk`, `secret`, `token`, `api_key`, `apikey`, `password`, `passphrase`, `bearer`, `mnemonic`, `seed`, `nonce` (when used as crypto material, not RPC nonce)
+- Whole-object logging that may contain nested credentials:
+  - `signed_order`, `signed_tx`, `signed_message`, `credentials`, `headers` (when headers contain `Authorization`)
+  - `request`, `response` objects logged in full
+- Full HTTP body / response logging that may include access tokens or PII
+
+**Why it's L not C:** the agent doesn't crash and consensus isn't broken; it's a security-posture issue. Severity escalates if the leaked material grants production access.
+
+**Fix:** redact / hash before logging; log only metadata (key prefix, length); log structured fields rather than entire objects.
+
+#### L5: Numeric Precision in Financial Logic
+
+**What:** Common precision footguns in code that touches token amounts, prices, or financial calculations:
+- `float` arithmetic on token amounts (silent rounding accumulates over many trades)
+- Mixing 6-decimal (USDC) and 18-decimal (most ERC-20) without explicit unit tracking
+- `==` / `!=` between two values where at least one is a `float`
+- Hardcoded float constants used in `int(... * 10**N)` conversions (exact bits of the float matter)
+- Arithmetic on results of older Solidity calls without checking for negative / overflow
+
+**Search patterns:**
+- `float(` inside files that handle on-chain balances or token amounts
+- Hardcoded float literals (e.g. `0.089935`) used in conversions
+- `==` / `!=` between two values when at least one is provably `float`
+- `Decimal` mixed with `float` in the same expression
+
+**Bug example:**
+```python
+FALLBACK_POL_TO_USD_RATE = 0.089935  # binary float — not exactly 0.089935
+amount_usd = pol_amount * FALLBACK_POL_TO_USD_RATE
+amount_usd_wei = int(amount_usd * (10**18))  # rounding accumulates
+```
+
+**Fix:** use integer wei (or `Decimal` with explicit precision); track decimals via a typed wrapper; never compare floats with `==`.
+
 ---
 
 ## False Positive Guidance
@@ -585,6 +737,82 @@ class MyBehaviour(BaseBehaviour):
 
 ---
 
+## Scope Extensions
+
+### Auditing `customs/` Strategies
+
+`customs/` directories (e.g. `customs/kelly_criterion/`, `customs/fixed_bet/`) are loaded by IPFS hash at runtime via `FILE_HASH_TO_STRATEGIES` and execute logic that drives the FSM's financial actions (e.g. bet sizing). They are out of scope for `skills/`-only audits but receive zero coverage today.
+
+**When to extend:** if the agent's `aea-config.yaml` or any `services/*/service.yaml` references `FILE_HASH_TO_STRATEGIES` (or a similarly named param mapping IPFS hashes to strategy modules), audit those strategy directories with a reduced checklist.
+
+**Reduced checklist for `customs/` modules:**
+- L4 (logging hygiene) — strategies often log inputs and intermediate values
+- L5 (numeric precision) — strategies typically compute bet sizing, expected value, Kelly fraction, etc.
+- M1-style: type contracts on entry/exit functions (what does the calling behaviour expect back?)
+- Error handling: do strategy functions degrade gracefully or raise into the calling behaviour? An uncaught exception in a strategy crashes the calling behaviour (audit-resilience Category A).
+
+**Skip:** FSM-only checks (C3, C4, M2, M3, M5, M7, M8, T*) — there is no FSM in a strategy.
+
+### Auditing `service.yaml` Overrides
+
+Both this skill and `audit-resilience` historically read package source only and miss runtime parameter overrides. If the audit scope is a service (not just a skill) and `services/*/service.yaml` exists:
+
+1. Parse each service's `overrides` block. List every parameter override, its target skill, and the override value.
+2. For overrides that change behaviour-controlling parameters (timeouts, retry counts, URLs, contract addresses, feature flags), flag if the override:
+   - Changes the value type from the default declared in the skill's `models.py` (e.g. int default, string override)
+   - Sets a value that conflicts with `db_pre_conditions` (e.g. an override that expects a key not provided by an upstream round)
+   - Disables a safety mechanism present in defaults (retry count to 0, timeout to a very large value, `verify=False`)
+3. When multiple `services/*/service.yaml` exist for the same agent (e.g. `trader_pearl/` vs `polymarket_trader/`), build a comparison table — drift between deployments is a footgun.
+4. Note: env-var-driven overrides (`${OAR_API_KEY:str:dummy}`) hide values entirely. Flag any param marked sensitive (URL, key, address) that defaults to `dummy` / empty / placeholder — production deployments depend on the env var being set.
+
+---
+
+## Methodology Guardrails
+
+These guardrails reduce false positives observed in prior audit runs. Apply them before flagging any finding.
+
+### Force the data-type trace before flagging type mismatches
+
+Many false positives in prior runs (M5 mismatches, T2 wrong-base-class claims, "non-existent payload field" claims) came from agents reasoning about **annotated** types instead of **runtime** types. In open-autonomy, payload fields and DB-backed properties are JSON-deserialized — the runtime type may differ from the annotation.
+
+When a check requires reasoning about a value's runtime type, before flagging:
+
+1. Locate the **last assignment** to the variable along the call path (do not stop at the type annotation).
+2. If that assignment is `json.loads(some_field)`, `self.db.get_strict(key)`, or a `BaseTxPayload` field whose value was JSON-serialized at write time, the runtime type is whatever the JSON producer wrote — which may be `dict`, `list`, `str`, `int`. Static annotations alone are not authoritative here.
+3. For framework-DB-backed properties, trace from `selection_key` → property body → any `json.loads(...)` to determine the actual runtime type.
+4. Do NOT flag a type mismatch unless you can name **both** the expected type AND the actual runtime type with a `file:line` citation for each.
+
+A concrete past failure: a discovery agent claimed `isinstance(actions_data, dict)` was dead because `synced_data.actions` was annotated `Optional[List[...]]`. The annotation was a stale guess; the runtime value came from `json.loads(content)` and could be either a dict or a list.
+
+### Strip framework-scheduled events from `end_block` completeness checks
+
+C3 explicitly carves these out (see C3 above). Repeating here as a guardrail because prior runs surfaced this false positive (a discovery agent flagged `Event.ROUND_TIMEOUT` as "missing from `CheckFundsRound.end_block()`" — `ROUND_TIMEOUT` is scheduled by the framework via `event_to_timeout`, not emitted by `end_block`).
+
+Before flagging an event as missing from `end_block()`:
+- If the event appears in `event_to_timeout` for the round, **skip it** — the framework schedules the transition.
+- If the event appears in the round's transition function but is neither a base-class event (`done`, `none`, `no_majority`, `fail`) nor in `event_to_timeout`, then it is genuinely missing — flag it under C3.
+
+### Single-finding-per-bug discipline
+
+If two checks (e.g. C3 dead transition + M8 misleading attribute) flag the same underlying bug, report once with both check IDs cited, not twice.
+
+---
+
+## Coverage Limitations
+
+This skill audits **FSM correctness and safety** in `skills/`. The following are explicitly NOT covered — the audit report should call this out so consumers know what they still need to do:
+
+- **External request resilience** → run `audit-resilience` (companion skill).
+- **Security review** → run `/security-review`. This skill does not audit private-key handling, env-var injection in `skill.yaml`, `eval` / `exec` patterns, unsafe deserialization (`pickle.loads`), or supply-chain risks.
+- **Numeric precision in financial logic** is L5-checked at a syntactic level only; mathematical correctness of strategy logic is out of scope.
+- **Dependency CVEs** → run `pip-audit` / `safety check` after this audit.
+- **Smart-contract audit** → out of scope; covered by Solidity-specific tooling.
+- **Performance / gas optimisation** → out of scope.
+
+Include a "What this audit did not cover" section in every report.
+
+---
+
 ## Analysis Procedure
 
 Follow these steps in order:
@@ -614,6 +842,8 @@ These tools catch issues the manual audit does not need to duplicate:
 
 **Include the output of these tools in the report.** If any fail, report them as findings but clearly distinguish in-scope failures from out-of-scope ones. Then proceed with the manual checks below, which cover semantic and logic issues these tools cannot detect.
 
+**Tooling-unavailable case.** If the CLI tools fail with `No module named 'packages.valory.skills.abstract_round_abci'` (or similar import errors), the local `packages/` tree is missing library skills that the project policy doesn't sync (some downstream repos forbid `autonomy packages sync --all` because it bypasses a curated dependency set). This is a project policy choice, not a bug. Note in the report: *"CLI tools could not run because library skills are not in the local tree; proceeded with manual checks."* Do NOT report this as a finding, and do NOT block the audit on it.
+
 ### Step 1: Discovery
 
 Determine the scope of the audit:
@@ -638,7 +868,7 @@ Launch up to **3 parallel Explore agents**, dividing skills evenly among them. E
    - `tests/test_rounds.py` — round test classes
    - `tests/test_behaviours.py` — behaviour test classes
 
-2. **Run all checks from the Audit Checklist** (C1–C4, H1–H3, M1–M5, T1–T6, L1–L3)
+2. **Run all checks from the Audit Checklist** (C1–C5, H1–H3, M1–M8, T1–T6, L1–L5)
 
 3. **Return findings** as a structured list with:
    - Check ID (e.g. C1, H2)
@@ -706,6 +936,15 @@ Present the audit report as follows:
 
 ## Notes
 [Any false-positive exclusions or caveats about the audit scope]
+
+## What This Audit Did Not Cover
+
+- External-request resilience (run `/audit-resilience`)
+- Security review of credential handling, env-var injection, unsafe deserialization (run `/security-review`)
+- Mathematical correctness of strategy logic (only syntactic L5 checks were applied)
+- Dependency CVEs (run `pip-audit` / `safety check`)
+- Smart-contract audit, gas optimisation
+- [Add any further scope exclusions specific to this audit run, e.g. "CLI tools could not run because library skills are not in the local tree"]
 ```
 
 If no findings at a severity level, include the section header with "No findings." underneath.

--- a/claude-skills/audit-fsm/SKILL.md
+++ b/claude-skills/audit-fsm/SKILL.md
@@ -844,20 +844,32 @@ Before manual inspection, run the framework's built-in analysis commands to catc
 autonomy analyse fsm-specs --package <skill-path>
 
 # These three run repo-wide (no package scoping available).
-# They may report errors from skills OUTSIDE the audit scope — note those
-# separately and only include in-scope failures as findings.
 autonomy analyse handlers
 autonomy analyse dialogues
 autonomy analyse docstrings
 ```
 
-These tools catch issues the manual audit does not need to duplicate:
-- `fsm-specs` validates that the FSM spec file, the docstring, and the `transition_function` definition are all consistent (**scoped** to target skill)
-- `handlers` verifies required handlers are defined and properly configured (**repo-wide**)
-- `dialogues` verifies dialogue definitions match protocol specifications (**repo-wide**)
-- `docstrings` checks the AbciApp class docstring matches the actual state machine definition (**repo-wide**)
+**Critical — filter unscoped output against `dev` packages only.** `handlers` / `dialogues` / `docstrings` walk every package under `packages/`, including framework-vendored ones in the `third_party` section of `packages/packages.json`. Findings against `third_party` packages belong to the upstream repo, not this audit. The composition / cross-skill analysis later in the audit STILL needs full visibility into those packages — but their CLI-tool errors are out-of-scope as findings.
 
-**Include the output of these tools in the report.** If any fail, report them as findings but clearly distinguish in-scope failures from out-of-scope ones. Then proceed with the manual checks below, which cover semantic and logic issues these tools cannot detect.
+Build the dev set once and reuse it across all unscoped tools:
+
+```bash
+# Each entry is "<type>/<author>/<name>/<version>"; on-disk path is
+# packages/<author>/<type>s/<name>
+jq -r '.dev | keys[]' packages/packages.json
+```
+
+For each error line emitted by `handlers` / `dialogues` / `docstrings`, drop the line if the cited path resolves under a `third_party` package (i.e. its `<author>/<type>s/<name>` is not in the dev set). The remaining lines are in-scope findings. Note in the report how many lines were filtered and from which third-party paths, so the consumer can see what was dropped and why.
+
+`fsm-specs` is already scoped — invoke it only on dev skills (and only on the `$ARGUMENTS` subset if provided).
+
+These tools catch issues the manual audit does not need to duplicate:
+- `fsm-specs` validates that the FSM spec file, the docstring, and the `transition_function` definition are all consistent (**scoped** to target skill — invoke per dev skill)
+- `handlers` verifies required handlers are defined and properly configured (**repo-wide; filter output to dev**)
+- `dialogues` verifies dialogue definitions match protocol specifications (**repo-wide; filter output to dev**)
+- `docstrings` checks the AbciApp class docstring matches the actual state machine definition (**repo-wide; filter output to dev**)
+
+**Include the (filtered) output of these tools in the report.** If any in-scope error remains, report it as a finding. Then proceed with the manual checks below, which cover semantic and logic issues these tools cannot detect — and which DO read across into library / `third_party` packages where composition requires it.
 
 **Tooling-unavailable case.** If the CLI tools fail with `No module named 'packages.valory.skills.abstract_round_abci'` (or similar import errors), the local `packages/` tree is missing library skills that the project policy doesn't sync (some downstream repos forbid `autonomy packages sync --all` because it bypasses a curated dependency set). This is a project policy choice, not a bug. Note in the report: *"CLI tools could not run because library skills are not in the local tree; proceeded with manual checks."* Do NOT report this as a finding, and do NOT block the audit on it.
 

--- a/claude-skills/audit-fsm/SKILL.md
+++ b/claude-skills/audit-fsm/SKILL.md
@@ -409,9 +409,12 @@ class InnerAppA(AbciApp):
 
 # In composition.py:
 abci_app_transition_mapping = {
-    FinishedAppARound: SomeInitialRound,
+    DoneRound: SomeInitialRound,
     # BUG: FailedRound and ImpossibleRound are reachable finals of InnerAppA
-    #      but absent from this mapping AND absent from composed_app.final_states
+    #      but absent from this mapping AND absent from composed_app.final_states.
+    #      chain() does NOT catch this — it only validates that present keys are
+    #      finals of inner apps; it doesn't enforce coverage of every reachable
+    #      inner final.
 }
 ```
 
@@ -551,7 +554,7 @@ class SynchronizedData(BaseSynchronizedData):
 
 #### M6: SynchronizedData JSON Round-Trip Safety
 
-**What:** Writes to `synchronized_data` go through `AbciAppDB.update()` which JSON-serializes values. Values that are not JSON-native (`set`, `Decimal`, `dataclass` instances, `datetime`, `tuple` of mixed types, custom enum members) silently lose fidelity (e.g. `tuple` → `list`) or raise `TypeError` at write time. Custom serializer hooks (e.g. `EGreedyPolicy.serialize` / `deserialize`) must be applied symmetrically on the read side.
+**What:** Writes to `synchronized_data` go through `AbciAppDB.update()`, which calls `AbciAppDB.validate(kwargs)` (`packages/valory/skills/abstract_round_abci/base.py:658-660`) BEFORE any storage step. `validate()` delegates to `is_json_serializable()` (`utils.py:408-417`), which only accepts primitives plus `tuple`/`list`/`dict` recursively. On failure it raises **`ABCIAppInternalError("AbciAppDB data must be json-serializable...")`** (`base.py:649-655`) — NOT Python's `TypeError` from `json.dumps`. Values that are JSON-native but lossy at the type level (e.g. `tuple` → `list` on the read side, `float` drift) survive validation but silently lose fidelity. Custom serializer hooks (e.g. `EGreedyPolicy.serialize` / `deserialize`) must be applied symmetrically on the read side.
 
 Plus: when a `SynchronizedData` subclass uses **multiple inheritance** to combine data classes from composed skills (e.g. `class SynchronizedData(MechInteractSyncedData, MarketManagerSyncedData, TxSettlementSyncedData)`), two parents defining the same property name silently shadow according to MRO order. The subclass author may believe they are reading from skill A's data when they're actually reading from skill B's.
 
@@ -562,11 +565,15 @@ Plus: when a `SynchronizedData` subclass uses **multiple inheritance** to combin
 
 **Bug examples:**
 ```python
-# BUG (write-time crash): set is not JSON-serializable — TypeError at write time
+# BUG (write-time crash): set is rejected by AbciAppDB.validate (base.py:649-655) —
+# raises ABCIAppInternalError("AbciAppDB data must be json-serializable..."),
+# NOT Python's TypeError from json.dumps
 self.synchronized_data.update(participants={agent1, agent2})
 
-# BUG (write-time crash): Decimal is not JSON-serializable — TypeError at write time
-# (same failure mode as set; do NOT mistake this for silent rounding to float)
+# BUG (write-time crash): same as above — Decimal is rejected by AbciAppDB.validate;
+# raises ABCIAppInternalError, not TypeError.
+# Do NOT mistake this for silent rounding to float — the validation layer
+# intercepts before json.dumps would be reached.
 self.synchronized_data.update(price=Decimal("0.123456789012345678"))
 
 # BUG (silent precision loss): float arithmetic drifts BEFORE serialization;

--- a/claude-skills/audit-fsm/SKILL.md
+++ b/claude-skills/audit-fsm/SKILL.md
@@ -387,6 +387,41 @@ Different agents may have different files → different events → consensus bre
 
 **Fix:** All non-deterministic data must be sourced from `synchronized_data` — i.e. agreed via consensus by the predecessor round's payload.
 
+#### C6: Unmapped Reachable Finals in Composition
+
+**What:** In `chain()`-composed AbciApps, every **final state of an inner app** that is not declared as a terminal state of the composed app must appear as a **key** in `abci_app_transition_mapping`. Otherwise the composed FSM reaches that state and stops — there is no transition out, the round emits no further events, and the agent hangs.
+
+**Important — what `chain()` does and does NOT validate.** The framework validates that mapping keys ARE final states of inner apps and that mapping values ARE initial states of other inner apps (`chain()` raises `ABCIAppInternalError` at construction time on violations). It does NOT verify that **every reachable inner final state** has been mapped. That is the gap this check covers.
+
+**How to check:**
+1. For each inner `AbciApp` in the chain, read `cls.final_states`.
+2. Compute `reachable_finals = ⋃ inner.final_states for inner in chained_apps`.
+3. Subtract:
+   - `composed_app.final_states` (states deliberately terminal in the composed FSM).
+   - `set(abci_app_transition_mapping.keys())` (states with an explicit successor).
+4. The remainder is the set of **unmapped reachable finals**. Each one is a hang on reach.
+
+**Bug example:**
+```python
+class InnerAppA(AbciApp):
+    final_states = {DoneRound, FailedRound, ImpossibleRound}
+
+# In composition.py:
+abci_app_transition_mapping = {
+    FinishedAppARound: SomeInitialRound,
+    # BUG: FailedRound and ImpossibleRound are reachable finals of InnerAppA
+    #      but absent from this mapping AND absent from composed_app.final_states
+}
+```
+
+At runtime: agent enters `InnerAppA`, takes a `FAIL_EVENT` transition to `FailedRound`, the round commits with no outbound event mapping → composed FSM hangs.
+
+**Severity rationale:** Same blast radius as C3 (transition function completeness). A round hang at composition level wedges the entire agent, with the same recovery profile.
+
+**Search pattern:** locate the module that calls `chain(...)` (typically `composition.py`); enumerate `final_states` of every inner app referenced; compare against the mapping keys plus the composed app's terminal set.
+
+**Why this needs to be its own check, not bundled under H2:** real audits have found this in production. Two unmapped finals in one repo's `composition.py` were the highest-impact FSM finding from a recent run and almost slipped through under H2's old "every mapping key/value valid" framing — those bullets are framework-validated and produce zero new findings, which masked the still-needed unmapped-finals check.
+
 ### High (H) — Issues with significant impact
 
 #### H1: Background App Configuration
@@ -401,15 +436,16 @@ Also check for shared mutable state between app configs (see C1).
 
 **Search pattern:** Grep for `BackgroundAppConfig`, `background_apps`, `bg_apps`.
 
-#### H2: Composition Chain Completeness
+#### H2: Composition Chain Completeness (Index)
 
-**What:** In composed apps using `chain()`:
-- Every final state in the mapping must be a valid final state of one of the composed apps
-- Every initial state target must be a valid initial state of one of the composed apps
-- `cross_period_persisted_keys` should include all keys needed by the first app in the chain
-- `abci_app_transition_mapping` must cover all final states that should lead to another app
+H2 used to bundle four bullets that have since been split or moved. Kept as an index so reports referencing H2 still resolve:
 
-**Search pattern:** Grep for `abci_app_transition_mapping`, `chain(`, `cross_period_persisted_keys`.
+- **Mapping key validity** ("every mapping key is a valid final state of an inner app") — **framework-validated** by `chain()` at construction time. Do NOT re-flag.
+- **Mapping value validity** ("every mapping value is a valid initial state of an inner app") — **framework-validated** by `chain()`. Do NOT re-flag.
+- **Unmapped reachable finals** ("every reachable inner final has a mapping entry or is composed-terminal") — see **C6**.
+- **`cross_period_persisted_keys` completeness for post-reset reads** — see **M7**.
+
+If a finding genuinely fits "composition chain completeness" but doesn't match any of the above, surface it under H2 as a free-form finding — but in practice, every prior H2-shaped finding maps cleanly to one of the four targets above.
 
 #### H3: Resource Lifecycle
 
@@ -419,6 +455,39 @@ Also check for shared mutable state between app configs (see C1).
 - `requests.get/post` without `timeout` parameter
 
 **Search pattern:** Grep for `open(`, `socket.socket(`, `.terminate()`, `Popen(`, `requests.get`, `requests.post` — then check surrounding context for proper cleanup.
+
+#### H4: `extended_requirements = ()` Override Without Compensating `end_block`
+
+**What:** `_MetaAbstractRound.__init__` (`packages/valory/skills/abstract_round_abci/base.py:1066-1068`) reads each round subclass's `extended_requirements` tuple and verifies via `hasattr` that every named class attribute is defined. This catches "subclass forgot to set `done_event` / `none_event` / `collection_key` / `selection_key`" at class-creation time.
+
+Setting `extended_requirements = ()` (or `tuple()`) in a subclass disables the loop — the metaclass passes any subset of attributes (including none). This is a legitimate escape hatch when the subclass overrides `end_block()` with custom logic that doesn't depend on the standard attributes.
+
+It becomes a **footgun** when:
+- The subclass omits one or more of the parent's required attributes, AND
+- The subclass inherits the parent's `end_block()` (which still reads those attributes).
+
+Result: class definition succeeds. The first time `end_block()` runs, `AttributeError: 'XRound' object has no attribute 'done_event'` (or `collection_key`, etc.) propagates uncaught from the behaviour generator — agent process crashes (`audit-resilience` Category A).
+
+**How to check:**
+1. Grep for `extended_requirements\s*=\s*\(\s*\)` and `extended_requirements:\s*Tuple.*=\s*\(\s*\)` and `extended_requirements\s*=\s*tuple\(\s*\)`.
+2. For each match, identify the parent class and look up its `extended_requirements` (e.g. `CollectSameUntilThresholdRound.extended_requirements` covers `done_event`, `no_majority_event`, `none_event`, `collection_key`, `selection_key`).
+3. Verify the subclass either:
+   - Defines a custom `end_block()` (and the override does NOT read the missing attributes), OR
+   - Defines all attributes that were in the parent's `extended_requirements` despite the override.
+4. If neither, this is crash-on-reach. Promote severity to **Critical** in the report (the subclass crashes the agent the first time it runs).
+
+**Bug example:**
+```python
+class AgentDBRound(CollectSameUntilThresholdRound):
+    payload_class = AgentDBPayload
+    extended_requirements = ()  # disables metaclass attribute check
+    # missing: done_event, none_event, no_majority_event, collection_key, selection_key
+    # inherits parent's end_block, which reads self.done_event → AttributeError at runtime
+```
+
+**Severity rationale:** Default H because legitimate uses of the empty override exist (custom-`end_block` rounds). Promote to C when the audit verifies the subclass inherits the parent's `end_block` AND omits at least one required attribute — that combination is a guaranteed crash.
+
+**Search pattern:** `extended_requirements\s*=\s*(\(\s*\)|tuple\(\s*\))` in any round module.
 
 ### Medium (M) — Issues that indicate potential problems
 
@@ -897,7 +966,7 @@ Launch up to **3 parallel Explore agents**, dividing skills evenly among them. E
    - `tests/test_rounds.py` — round test classes
    - `tests/test_behaviours.py` — behaviour test classes
 
-2. **Run all checks from the Audit Checklist** (C1–C5, H1–H3, M1–M8, T1–T6, L1–L5)
+2. **Run all checks from the Audit Checklist** (C1–C6, H1–H4, M1–M8, T1–T6, L1–L5)
 
 3. **Return findings** as a structured list with:
    - Check ID (e.g. C1, H2)

--- a/claude-skills/audit-fsm/SKILL.md
+++ b/claude-skills/audit-fsm/SKILL.md
@@ -192,7 +192,7 @@ A skill with `is_abstract: true` in its `skill.yaml` is composition-only — it 
 - **Demote** "missing handler" findings to informational unless the handler is required for composition (e.g. an `ABCIHandler` is mandatory).
 - **Apply** the same M2 / C4 carve-outs as library skills (unused events / dead timeouts may be intentional extension points).
 
-The `agent_performance` "missing dialogues" / "missing fsm_specification" findings from prior audits worked out only because the CLI tool happened to fail. With the `is_abstract` branch, those findings are correctly suppressed at the source.
+Prior audits avoided false positives on the `agent_performance` "missing dialogues" / "missing fsm_specification" findings only by accident — the CLI tool failed before reaching these checks. The `is_abstract` branch now makes the suppression deliberate.
 
 ### Test Infrastructure
 
@@ -357,7 +357,7 @@ if (
 
 **Search patterns inside `end_block()` bodies (and any helper called from `end_block`):**
 - File I/O: `open(`, `Path.read_*`, `json.load(open(`, `os.path.exists(`, `pathlib.*`
-- Wall clock: `time.time()`, `datetime.now()`, `datetime.utcnow()`, `time.monotonic()` — use `synchronized_data.last_round_transition_timestamp` instead (set by the framework from agreed block time)
+- Wall clock: `time.time()`, `datetime.now()`, `datetime.utcnow()`, `time.monotonic()` — use `self.context.state.round_sequence.last_round_transition_timestamp` (the agreed Tendermint block time of the last transition, set on `RoundSequence` from `self._blockchain.last_block.timestamp` — see `packages/valory/skills/abstract_round_abci/base.py`), or read a timestamp written into a payload field by a predecessor round (consensus-agreed, then surfaced via `synchronized_data`)
 - Randomness: `random.*`, `secrets.*`, `os.urandom(` — use `synchronized_data.most_voted_randomness` (consensus randomness)
 - Environment: `os.environ.get(`, `os.getenv(`
 - Network / external services: `requests.*`, `urlopen(`, `socket.*`, `subprocess.*`, contract calls, IPFS reads

--- a/claude-skills/audit-fsm/SKILL.md
+++ b/claude-skills/audit-fsm/SKILL.md
@@ -771,6 +771,23 @@ Both this skill and `audit-resilience` historically read package source only and
 
 These guardrails reduce false positives observed in prior audit runs. Apply them before flagging any finding.
 
+### Verify every sub-agent finding before accepting it
+
+The Step 2 Explore agents return **candidate** findings with **candidate** severities, not final ones. The spawning agent (you) MUST hand-verify each candidate against the source before promoting it into the report. Sub-agents over-report because they lack the cross-cutting view across the audit scope.
+
+For each candidate finding from a sub-agent, before accepting:
+
+1. **Read the cited `file:line` in the actual source.** Confirm the bug exists as described — not a misread of static type vs runtime type, not a paraphrase that drifts from the actual code, not a citation pointing at the wrong line.
+2. **Confirm the bug is real.** Apply the data-type trace guardrail (below). Apply the framework-scheduled-event carve-out (below). Check the False Positive Guidance section.
+3. **Re-evaluate severity.** Sub-agents systematically over-classify. Concretely:
+   - "Unused / dead code" (initial-only attributes, dead comments, vestigial fields) is **almost always L**, not C. Critical requires runtime impact.
+   - A misnamed-but-harmless attribute is **L**, not C. Promote only if you can demonstrate a runtime path that reads / writes through it incorrectly.
+   - Configuration that "looks misleading" is **L** unless misleading the reader produced (or is highly likely to produce) a downstream bug.
+4. **Consolidate split findings.** If three sub-agent findings point at one root cause (e.g. three separate Cs that all stem from one mis-typed `AgentDB` accessor), report ONCE at the appropriate severity, not three times.
+5. **Demote liberally.** If you can't reproduce the sub-agent's reasoning from the source in under a minute, the finding is probably wrong — drop it or downgrade to L with an "informational" note.
+
+Sub-agent classification is input, not output. The report is your judgment, not the union of subagent outputs.
+
 ### Force the data-type trace before flagging type mismatches
 
 Many false positives in prior runs (M5 mismatches, T2 wrong-base-class claims, "non-existent payload field" claims) came from agents reasoning about **annotated** types instead of **runtime** types. In open-autonomy, payload fields and DB-backed properties are JSON-deserialized — the runtime type may differ from the annotation.

--- a/claude-skills/audit-resilience/SKILL.md
+++ b/claude-skills/audit-resilience/SKILL.md
@@ -91,9 +91,16 @@ What happens after a behaviour crash:
 
 Synchronous connections (e.g., `PolymarketClientConnection`) use `BaseSyncConnection` which dispatches `on_send` via `_run_in_pool` into a `ThreadPoolExecutor`.
 
-**Critical:** If `MAX_WORKER_THREADS = 1` (common pattern), only one request can be processed at a time. If a request handler blocks (hanging HTTP call with no timeout, or `time.sleep()` during retries), **ALL subsequent requests queue behind it**. The agent's FSM continues but cannot interact with that connection at all.
+#### Canonical: `MAX_WORKER_THREADS=1` + no-timeout call = subsystem outage
 
-Additional threading details:
+This is the single most common indefinite-hang shape in open-autonomy connections. Every reference elsewhere in this skill (BP8, the priority rules, the quality checklist, the Step 3 stuck identification) points back here:
+
+> If `MAX_WORKER_THREADS = 1` (common pattern), only one request can be processed at a time. If a request handler blocks — hanging HTTP call with no timeout, `time.sleep()` during retries, third-party library that wraps HTTP without timeout configured (`httpx.Client(http2=True)`, internal `requests.request(...)` calls in vendor SDKs) — **ALL subsequent requests queue behind it**. The agent's FSM continues but cannot interact with that connection at all. Recovery requires an agent restart.
+
+When you see any of these in combination, treat it as the canonical pattern: `MAX_WORKER_THREADS=1` + a call site that can hang + no enforcement timeout at the calling layer.
+
+#### Additional threading details
+
 - `on_send()` runs in the pool thread. If it crashes (e.g., `json.loads` of a malformed SRR payload), the `_task_done_callback` logs the exception but **no response envelope is ever sent**. The skill behaviour waiting for the response will time out.
 - The `_route_request()` dispatcher typically has a broad `except Exception` catch-all that converts any exception into an error response — this is the safety net for unhandled exceptions in request handlers. But code OUTSIDE `_route_request()` (e.g., payload deserialization in `on_send()`) is NOT protected.
 
@@ -297,8 +304,7 @@ The agent process is alive but unable to make progress.
 - Can the FSM enter a loop (reset → retry → fail → reset)?
 - Are there any `thread.join()` without timeout?
 - Is `wait_for_transaction_receipt()` called without timeout?
-- Do third-party library HTTP clients have timeout configured? (Check httpx.Client AND requests internally)
-- Is `MAX_WORKER_THREADS=1`? Can a single blocking call stall all operations for that connection?
+- Does this match the canonical `MAX_WORKER_THREADS=1` + indefinite-hang call pattern? (See architecture reference and BP8.) Includes third-party HTTP client wrappers without internal timeouts (`httpx.Client`, internal `requests.request`).
 - Is `json.loads` of inbound payloads outside the `_route_request` try-except?
 
 **For each stuck path, determine:**
@@ -406,20 +412,23 @@ FALLBACK_RATE = 0.089935  # From 2026-02-11 — goes stale over time
 
 ### BP8: Thread blocking without timeout
 
+A call site that can block for longer than the calling round's `round_timeout` (or, in single-worker connections, longer than any operator-tolerated outage window). Two flavours:
+
 ```python
-# BUG: Blocks thread for up to 60 seconds
+# BUG: long timeout on Web3 — blocks the thread for up to 60s
 receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=60)
 ```
 
-Also check for **no timeout at all** in third-party libraries:
 ```python
-# BUG: httpx.Client with no timeout — blocks indefinitely
-client = httpx.Client(http2=True)  # No timeout!
-# BUG: requests.request with no timeout — blocks indefinitely
-response = requests.request("POST", url, json=data)  # No timeout!
+# BUG: no timeout at all — third-party SDKs that wrap requests / httpx
+# without configuring a timeout block indefinitely. Common cases:
+#   - py_clob_client → httpx.Client(http2=True)   no timeout
+#   - py_builder_relayer_client → requests.request(...) no timeout
 ```
 
-**Fix:** Use shorter timeout, or run in a separate thread pool. For third-party libraries where you can't modify the source: wrap calls with `concurrent.futures.ThreadPoolExecutor` + `future.result(timeout=N)` to enforce a deadline at the calling layer, or set environment variables if the library respects them (e.g. `HTTPX_DEFAULT_TIMEOUT`). Check `pyproject.toml` to determine if a dependency is third-party (pinned version, installed via pip) vs internal (editable, in-repo).
+**See the canonical statement** in the "BaseSyncConnection Threading Model" architecture reference for why `MAX_WORKER_THREADS=1` + any indefinite-hang call site = subsystem outage. BP8 is the actionable check; that section explains the mechanism.
+
+**Fix:** use a short timeout where the API supports one. Where you can't modify the third-party source, enforce a deadline at the calling layer with `concurrent.futures.ThreadPoolExecutor` + `future.result(timeout=N)`, or set library-respected env vars (e.g. `HTTPX_DEFAULT_TIMEOUT`). Check `pyproject.toml` to decide whether the dep is editable / in-repo (you can patch it) vs pinned third-party (you must wrap).
 
 ### BP9: Retry backoff exceeding round timeout
 
@@ -637,6 +646,43 @@ Signed orders, EIP-712 typed data, relayer transactions, and many exchange APIs 
 
 **Note:** this intersects with `audit-fsm` C5 (determinism in `end_block`). A timestamp produced in `end_block` must come from `synchronized_data`, not `time.time()`.
 
+### BP23: `MagicMock` Without `spec=` Hides Production-Only Bugs
+
+A meta-resilience pattern: tests pass, prod crashes. `MagicMock(...)` (and `Mock(...)`, `AsyncMock(...)`) without a `spec=` / `spec_set=` argument auto-vivifies any attribute access — `mock.foo`, `mock.bar.baz`, `mock.does_not_exist()` all succeed and return fresh MagicMocks. When a test mocks an HTTP response, an SDK client, or a connection object, **missing-attribute or attribute-rename bugs in the production code path silently pass tests** because the mock obligingly provides whatever the production code asks for.
+
+Bug shapes this hides:
+- Production code reads `response.body` but the test sets `MagicMock(text="...")`. In the real call site, `response.body` is bytes that need decoding; the mock test never exercises the `.decode()` failure.
+- Production code's accessor was renamed (`.text` → `.json()`); tests still pass `MagicMock(text="...")` and don't notice. Or vice versa.
+- Production code accesses a method that no longer exists on the upstream library — mock provides it anyway.
+
+Concrete past finding: an `AgentDB` connection's `response.text` access bug went undetected because tests used `MagicMock(text="...")` — without `spec=`, missing-attribute failures silently succeeded in tests.
+
+**Search pattern (in `tests/` directories within audit scope):**
+- `MagicMock(`, `Mock(`, `AsyncMock(` calls used to substitute for HTTP responses, SDK clients, or connection objects
+- `mocker.patch(...)` / `mocker.patch.object(...)` whose `return_value` is unspecced
+- Any `Mock` whose attributes are populated only via `mock.foo = ...` post-hoc (no `spec=`)
+
+For each, verify a `spec=ClassName` (or `spec_set=ClassName`) argument is present. If not, flag the test as a candidate false-negative.
+
+**Bug example:**
+```python
+# BUG: any attribute access on this mock succeeds; missing attributes return MagicMocks
+mock_response = MagicMock(text="ok", status_code=200)
+# If production reads response.body, mock returns a fresh MagicMock — test passes
+# In prod, real Response.body is bytes; downstream .decode() fails on binary content
+
+# Fix: spec= constrains attribute access to the spec class's attribute set
+from requests import Response
+mock_response = MagicMock(spec=Response)
+mock_response.text = "ok"
+mock_response.status_code = 200
+# mock_response.body now raises AttributeError — bug surfaces in test
+```
+
+**Severity guidance:**
+- If the underlying production bug masked by the mock is P0/P1, flag the test pattern as the **regression-escape root cause** and pull the severity through.
+- Otherwise, this is **P3** — systemic test hygiene. But list every unspec'd HTTP/SDK mock in the audit scope; the next BP1-BP22 finding could easily be hidden behind one.
+
 ---
 
 ## Cross-cutting Issues to Check
@@ -800,8 +846,8 @@ For each external endpoint discovered, launch analysis agents (up to 3 in parall
 3. Fills in the failure matrix for all failure modes (Step 1)
 4. Traces FSM impact (Step 2) — including composed FSM transitions in `composition.py`
 5. Classifies operational impact (Step 3)
-6. Checks for all bug patterns (BP1–BP22)
-7. Applies the Methodology Guardrails (data-type trace, BP1 reminder) before flagging
+6. Checks for all bug patterns (BP1–BP23)
+7. Applies the Methodology Guardrails (data-type trace, BP1 reminder, sub-agent verification) before flagging
 
 ### Step C: Cross-cutting Analysis
 
@@ -1005,6 +1051,7 @@ Before finalizing the report, verify:
 - [ ] **BP20** — every paginated fetch documents partial-failure semantics
 - [ ] **BP21** — every external response with potentially unbounded size has a size cap
 - [ ] **BP22** — signed payloads with timestamps use consensus-safe time when in a multi-agent service
+- [ ] **BP23** — every `MagicMock` / `Mock` / `AsyncMock` substituting for an HTTP response, SDK client, or connection object uses `spec=`
 - [ ] **CC8** — worst-case-blocking vs round_timeout computed for every call site
 - [ ] **CC9** — observability table built; rows that are mostly ✗ on failure are flagged
 - [ ] `services/*/service.yaml` overrides parsed and resilience-relevant changes flagged

--- a/claude-skills/audit-resilience/SKILL.md
+++ b/claude-skills/audit-resilience/SKILL.md
@@ -486,6 +486,156 @@ response, error = self._route_request(payload=payload)
 
 **Fix:** Move deserialization inside `_route_request` or add try-except in `on_send`.
 
+### BP15: Idempotency on Retry of Financial Actions
+
+**The single biggest gap in resilience review for trading services.** BP8 / BP9 flag blocking timeouts. BP15 asks the harder question: *if this call retries — at the connection layer OR via FSM round re-entry — can it duplicate a financial action?*
+
+The pattern: a connection-layer call to a non-idempotent endpoint (place order, redeem, set approval, transfer, swap) returns an error or times out **after** the upstream has accepted the request. The agent's behaviour sees the failure, the round eventually times out, the FSM transitions to a retry path, and the next period re-enters the same call site. Two side-effects on the upstream from one logical action.
+
+Even if the connection itself does not retry, the **FSM retries the entire round** on its own timeout. CLOB nonces, on-chain nonces, and Safe nonces protect *some* of this — but the audit must flag the *pattern* and verify the dedup mechanism per call site.
+
+**How to check, per non-idempotent POST / state-changing call:**
+
+1. **Identify the call site and the calling round.** Grep for `requests.post`, `httpx.post`, third-party client `.execute() / .post_order() / .submit_*()`, contract `.transact()`, etc.
+2. **Determine whether the round can re-enter the call after its timeout fires.** Walk the `transition_function`: does the round timeout path eventually loop back to this round?
+3. **Document the dedup mechanism** at this call site:
+   - **On-chain nonce / sequence number** (CLOB nonce, Safe nonce, ETH transaction nonce, sequencer-enforced ordering) — usually safe; verify the nonce is actually included in the signed payload.
+   - **Idempotency key in request payload** (`Idempotency-Key` header, `client_order_id`, `request_id`) — safe **if the upstream honours it** (check the API docs / library source).
+   - **On-chain check before submit** (read state, then write only if not already done) — TOCTOU-prone but generally acceptable.
+   - **None of the above** — flag as **P1** (financial impact). The bug is that two independent attempts on a flaky network produce two upstream side-effects.
+4. **For relayer / exchange APIs**, check the upstream contract: does the API guarantee idempotency, or is dedup the client's responsibility?
+
+**Bug example:**
+```python
+# polymarket_client/connection.py — bet placement, no idempotency key
+def _place_bet(self, order_args):
+    signed = self._client.create_order(order_args)
+    response = self._client.post_order(signed)  # ← network error after upstream accepts
+    # No idempotency key, no on-chain dedup — FSM retries this round → duplicate order
+```
+
+**Why it matters:** Direct financial impact. A 1-in-1000 transient network blip, taken across a busy trading service, produces a duplicate order roughly daily.
+
+### BP16: Stringified-Exception Retry Conditions
+
+```python
+# BUG: retry decision based on substring match of exception message
+try:
+    return self._client.do_thing()
+except Exception as e:
+    if "rate limit exceeded" not in str(e).lower():
+        raise
+    # else retry
+```
+
+Two failure modes:
+1. **Upstream message format changes** → the substring no longer matches → retry silently stops working (the retry path becomes dead code with no test coverage).
+2. **Unrelated exception** whose `str()` happens to contain the substring → retries inappropriately on a non-transient error (e.g. an auth failure with the word "exceeded" in it).
+
+**Search pattern (inside `except` blocks):**
+- `in str(e)`, `in repr(e)`, `in str(exception)`, `in str(exc)`
+- `e.args[0] ==`, `e.message ==`, `f"{e}".lower()`
+
+**Fix:** prefer `isinstance(e, SpecificError)`; check `response.status_code` on the response; use library-provided exception types where available (`RateLimitError`, `httpx.HTTPStatusError`, etc.).
+
+### BP17: Defined-but-Unenforced Security Allowlists
+
+```python
+class _Connection:
+    _ALLOWED_METHODS = {"get_user", "post_event"}     # actually enforced via dispatch
+    _VALID_ENDPOINTS = {re.compile(r"/v1/[a-z]+/?$")}  # ← never referenced!
+```
+
+A class-level constant whose name implies enforcement but is never actually consulted. Looks like security config; isn't. Often shows up alongside a real allowlist that *is* enforced — the dead one gives a false sense of defence-in-depth.
+
+**Search pattern:** enumerate class-level constants whose name contains `VALID|ALLOWED|PERMITTED|DENY|BLOCK|WHITELIST|BLACKLIST|FORBIDDEN`. For each, grep the class body (and any subclass) for references. Unreferenced → finding.
+
+**Fix:** wire the allowlist into the dispatch path, or remove it.
+
+### BP18: Inverted Fail-Safe on Unknown State
+
+```python
+# BUG: external check returned "unknown" → assumed optimistic outcome
+balance = self._check_balance(...)  # returns None on RPC failure
+if balance is None:
+    self.context.logger.warning("Could not check balance, skipping")
+    state.sufficient_funds = True   # ← optimistic default
+    return True
+```
+
+The external dependency returned "unknown" (RPC down, response malformed). The handler claims the optimistic outcome — funds OK — and downstream code proceeds to spend funds it never verified existed. The observability gap (RPC down) silently becomes a financial-action error (failed payment, failed swap, failed deposit) at the gateway / counterparty.
+
+**Search pattern:** `if X is None:` or `if not X:` followed within a few lines by an assignment that sets a state flag to `True` or a permissive default, where `X` was assigned from a fallible external call. Particularly suspicious when the comment says "skipping" — that often signals the author chose the optimistic path on purpose.
+
+**Fix:** invert to the conservative outcome (`sufficient_funds = False`, `proceed = False`); OR model an explicit third state (`enum: Sufficient | Insufficient | Unknown`) so callers can distinguish "unable to check" from "checked and OK".
+
+**Why it matters:** This pattern silently turns an upstream observability gap into a downstream financial error. The agent appears healthy; the failure surfaces at the counterparty side, with no audit trail upstream.
+
+### BP19: TLS Verification Disabled / Hardcoded Credentials
+
+Grep-level checks. Each finding is independent; flag every match.
+
+- **`verify=False`** on `requests.*` / `httpx.*` / `aiohttp.*` — disables TLS certificate verification, opens MITM. Search: `verify=False`, `verify = False`, `ssl=False`, `ssl_context=None` in HTTP-call sites.
+- **API keys / tokens hardcoded as string literals** — search for assignment patterns: `api_key\s*=\s*"`, `token\s*=\s*"`, `secret\s*=\s*"`, `Bearer ` literal. Cross-reference against `.gitleaks` output if available.
+- **Secrets in URL query strings** — `?apikey=`, `?token=`, `?api_key=`, `?key=` — these end up in HTTP server logs, proxy logs, and browser histories. Headers are safer.
+- **`set_api_creds` failure paths** — when credential setup can fail (e.g. `client.create_or_derive_api_key()`), is the connection gracefully marked unusable, or does it silently allow unauthenticated traffic? Trace from the credential-setup call to the first request.
+
+**Fix:** never disable TLS in production code; load secrets from env vars or a secrets manager; pass via headers; fail closed on credential-setup error.
+
+### BP20: Pagination Partial-Failure Semantics
+
+```python
+# Typical paginator
+results = []
+page = 0
+while True:
+    resp, err = self._fetch_page(page)
+    if err is not None:
+        return None, err   # ← partial accumulation discarded
+    if not resp:
+        break
+    results.extend(resp)
+    page += 1
+return results, None
+```
+
+A `while True:` paginator that fetches pages 1..N and accumulates. If page 5 fails (5xx or timeout), the typical pattern returns `None, error` and the partially accumulated list is discarded. Whether this is *correct* depends entirely on the caller's contract — and that contract is rarely documented.
+
+**How to check, per paginated fetch:**
+1. Identify the loop and the accumulator variable.
+2. Locate the failure return path — does it return the partial list, an empty list, `None`, or raise?
+3. Identify all callers and ask: do they treat partial as "no data," pass-through, or expect "all-or-nothing"?
+4. Flag mismatches: caller assumes complete data, paginator returns partial; or caller wants partial, paginator drops it.
+
+**Fix:** make the contract explicit at the function signature level — return type `Tuple[List, Optional[Error]]` for partial-OK, or raise / return `(None, error)` for all-or-nothing. Document at the call site.
+
+### BP21: Response Size Bounds
+
+External calls that can return arbitrarily large responses are a memory and latency footgun:
+
+- **Subgraph queries with no `first:` / `limit:` / `skip:` clause** — The Graph defaults can return thousands of records.
+- **Iterating an unbounded list from an external source** in memory (e.g. `mech_responses` loop, full chat history fetch).
+- **Streaming binary responses through `response.body.decode()` or `response.text` without size check** — covered partly by BP5 for malformed bytes; BP21 is the *size* dimension, not the encoding dimension.
+- **`requests.get(...).content`** with no `stream=True` and no max-size guard — entire body loaded into memory.
+
+**Fix:** enforce size limits at the call site (`len(response.content) > MAX_BYTES`); chunk via pagination with explicit page-size; reject responses > N bytes; for subgraph, always specify `first: 1000` (or appropriate cap).
+
+### BP22: Clock-Window-Signed Requests
+
+Signed orders, EIP-712 typed data, relayer transactions, and many exchange APIs include a **timestamp** plus an **expiry window**. Two failure modes:
+
+1. **Agent clock drift vs upstream** — if the agent's wall clock is more than the expiry window off, every signed request fails signature verification. Drift can be invisible until NTP misconfigures.
+2. **Multi-agent timestamp divergence** — in a multi-agent service, agents that build the same payload independently see different `time.time()` values. The aggregated payload is rejected for one set of agents and accepted for another, partitioning consensus.
+
+**How to check:**
+1. Find call sites that build a signed payload for an external counterparty: relayer / exchange POSTs, EIP-712 messages, signed orders.
+2. Inspect how the payload's `timestamp` / `nonce` / `expiry` is computed.
+   - `time.time()` / `datetime.now()` → drift-prone, **NOT consensus-safe** in a multi-agent service.
+   - `last_round_transition_timestamp` from `synchronized_data` → consensus-safe (it is the agreed block time, not an agent-local timestamp).
+3. Verify the agent's NTP / clock-sync mechanism if `time.time()` is used. Document the deployment expectation.
+
+**Note:** this intersects with `audit-fsm` C5 (determinism in `end_block`). A timestamp produced in `end_block` must come from `synchronized_data`, not `time.time()`.
+
 ---
 
 ## Cross-cutting Issues to Check
@@ -516,6 +666,101 @@ If multiple threads access shared state (e.g., a cached price dict), are there r
 ### CC7: `{"data": null}` vs `{"data": {}}` inconsistency
 Check if `.get("data", {})` patterns consistently use `or {}` guards. Inconsistent application means some code paths crash on null values while others handle them.
 
+### CC8: Worst-Case Blocking vs Round Timeout
+
+For each external call site, you already gathered (in Step 1) the worst-case blocking time: `sum of retry delays + per-attempt timeouts + library-internal blocking`. Now compare it against the `round_timeout` of the round that calls it.
+
+**If `worst_case_blocking > round_timeout`:** the round's timeout fires while the worker is still blocked. The FSM transitions on, but the worker thread keeps running until the underlying I/O completes. This produces:
+- **Orphaned threads** that accumulate over time (file descriptors, HTTP connections, cached state).
+- **Re-entrancy bugs** — the next period enters the same call site while the previous worker is still running.
+- **Resource leaks** — most acute on connections with `MAX_WORKER_THREADS=1`, where the next request queues behind the orphan.
+
+**How to check:**
+1. For each call site, compute worst-case blocking from the data already gathered in Step 1.
+2. Look up `round_timeout` for the calling round in `models.Params` or via `event_to_timeout` → ROUND_TIMEOUT.
+3. Flag any site where `worst_case_blocking > round_timeout`.
+
+**Concrete past finding:** trader's polymarket retry budget was 60 s; `BetPlacementRound.round_timeout` was 30 s. The round transitioned out before the connection responded, leaving an orphaned worker thread that kept running after the FSM had moved on.
+
+**Fix:** cap retry budget at `round_timeout / 2`; OR move the call to a cancellable executor with `future.result(timeout=...)`; OR raise the round_timeout if the upstream genuinely needs the longer budget (with caveats — see CC2 circuit breaker).
+
+### CC9: Observability Table per Call Site
+
+The skill already flags individual logging gaps (CC3 inconsistent error reporting). CC9 is the *catalog*: build a table per call site so reviewers see the systemic pattern at a glance. Without this, stale fallback values (BP7) and silent `return None` failures stay invisible until P&L diverges.
+
+| Call site | Logs success | Logs failure | Emits metric | Bubbles to UI |
+|---|---|---|---|---|
+| `behaviours/foo.py:123` | ✓ INFO | ✓ ERROR | ✗ | ✗ |
+| `behaviours/bar.py:45` | ✗ | ✓ WARNING | ✗ | partial |
+| ... | | | | |
+
+A row that is mostly ✗ on the failure side is the high-leverage finding — that call site can fail invisibly. Combine this with BP7 (stale fallback) to identify "stale rate goes silent, agent trades on it for weeks" patterns.
+
+---
+
+## Scope Extension: `service.yaml` Overrides
+
+Both this skill and `audit-fsm` historically read package source only and miss runtime parameter overrides. If `services/*/service.yaml` exists in the audit scope:
+
+1. Parse the `overrides` block. Build a table of every overridden param, its target skill, and the override value.
+2. For overrides that change resilience-relevant parameters, flag if the override:
+   - Disables a safety mechanism (retry count to 0; timeout set to a very large value or `null`; `verify=False`)
+   - Changes a URL to one with different TLS / auth requirements (e.g. http instead of https)
+   - Sets an API key / token to an env var that defaults to a placeholder (`${OAR_API_KEY:str:dummy}`) — production deployments depend on the env var being set; if it isn't, the agent makes anonymous requests
+3. When multiple `services/*/service.yaml` exist for the same agent, build a comparison table — drift between deployments often hides resilience regressions in one variant but not the other.
+
+Past examples worth flagging by name: trader's `trader_pearl/` (Omenstrat) vs `polymarket_trader/` (Polystrat); meme-ooorr's env-var-driven X402 gateway URL + API key wiring.
+
+---
+
+## Methodology Guardrails
+
+These guardrails reduce false positives observed in prior runs. Apply them before flagging any finding.
+
+### Force the data-type trace before flagging
+
+When a check requires reasoning about a value's runtime type (BP1 dispatch, BP2 null guards, "type X passed where Y expected" claims), reason about the **runtime** type, not the static annotation. In open-autonomy, payload fields and DB-backed properties are JSON-deserialized — the runtime type may differ from the annotation.
+
+Before flagging:
+1. Locate the **last assignment** to the variable along the call path.
+2. If that assignment is `json.loads(...)`, `self.db.get_strict(...)`, or a payload field whose value was JSON-serialized at write time, the runtime type is whatever the producer wrote — `dict`, `list`, `str`, `int` — not the annotation.
+3. Do NOT flag a type mismatch unless you can name **both** the expected type AND the actual runtime type with `file:line` citations for each.
+
+A concrete past failure: ~5 false positives in one run, all "JSONDecodeError uncaught" claims that were inside `except ValueError` blocks. BP1 already covers this — `JSONDecodeError` is a `ValueError` subclass — but the discovery agent didn't internalize the rule at the point of application.
+
+### Pre-flag BP1 reminder (verbatim)
+
+Before flagging "JSONDecodeError uncaught" / "missing JSON error handling" at any `response.json()` or `json.loads(...)` call:
+
+1. Read the surrounding `except` clause(s).
+2. If the except clause is `except ValueError`, `except (..., ValueError)`, `except Exception`, or any superclass of `ValueError` — **the JSON error IS caught.** Do not flag.
+3. Only flag if the except clause is strictly more specific than `ValueError` (e.g. only `RequestException`, `KeyError`, or specific custom exceptions) AND `JSONDecodeError` would escape uncaught.
+
+Belt-and-suspenders, since BP1 already documents the rule. The reminder exists because discovery agents have repeatedly flagged false positives here.
+
+### Strip framework-scheduled events from end_block reasoning
+
+When tracing FSM impact (Step 2) and you observe a transition that fires on an event scheduled by `event_to_timeout` (most commonly `ROUND_TIMEOUT`): that event is dispatched by the framework, not emitted by `end_block()`. Don't reason about it as if a behaviour returns it — model it as a wall-clock timeout that the framework injects.
+
+### Single-finding-per-bug discipline
+
+If a call site is flagged by multiple BPs (e.g. BP8 no-timeout AND BP15 idempotency AND CC8 worst-case blocking), report once with all relevant BP IDs cited, not three times.
+
+---
+
+## Coverage Limitations
+
+This skill audits **external-request resilience**. The following are explicitly NOT covered — the audit report should call this out so consumers know what they still need to do:
+
+- **FSM correctness and safety** → run `/audit-fsm` (companion skill).
+- **Security review** of credential handling, env-var injection in `skill.yaml`, `eval` / `exec` patterns, unsafe deserialization (`pickle.loads`) → run `/security-review`.
+- **Dependency CVEs / pinning currency** for `httpx`, `requests`, `web3`, `py_clob_client`, etc. → run `pip-audit` / `safety check` after this audit. Out of scope for a static audit.
+- **Mathematical correctness** of strategy / pricing logic — out of scope.
+- **Smart-contract resilience** (reentrancy, gas griefing, ordering attacks) — out of scope.
+- **Network / load testing** under sustained outage — out of scope; this audit is static.
+
+Include a "What this audit did not cover" section in every report.
+
 ---
 
 ## Analysis Procedure
@@ -537,7 +782,8 @@ For each external endpoint discovered, launch analysis agents (up to 3 in parall
 3. Fills in the failure matrix for all failure modes (Step 1)
 4. Traces FSM impact (Step 2) — including composed FSM transitions in `composition.py`
 5. Classifies operational impact (Step 3)
-6. Checks for all bug patterns (BP1–BP14)
+6. Checks for all bug patterns (BP1–BP22)
+7. Applies the Methodology Guardrails (data-type trace, BP1 reminder) before flagging
 
 ### Step C: Cross-cutting Analysis
 
@@ -550,6 +796,9 @@ After all endpoints are analyzed:
 6. Check httpx clients and Web3 HTTPProvider for missing timeouts (CC5)
 7. Check shared state access patterns (CC6)
 8. Check `{"data": null}` guard consistency (CC7)
+9. Compute worst-case-blocking vs round_timeout per call site (CC8)
+10. Build the per-call-site observability table (CC9)
+11. Parse `services/*/service.yaml` overrides and flag resilience-relevant changes (Scope Extension)
 
 ### Step D: Generate Report
 
@@ -670,10 +919,35 @@ Deep analysis of every external HTTP dependency: what happens under each failure
 | Priority | Issue | Category | Fix complexity | Fix description |
 |----------|-------|----------|----------------|-----------------|
 | **P0** | [Agent crashes] | Crash | Low/Med/High | [Specific fix] |
-| **P1** | [Financial impact side-effects] | Side-effect | | |
+| **P1** | [Financial impact side-effects, idempotency-on-retry gaps] | Side-effect | | |
 | **P2** | [Important bugs] | Various | | |
 | **P3** | [Systemic improvements] | All | | |
 | **P4** | [Low-impact fixes] | Various | | |
+
+---
+
+## Observability Table (CC9)
+
+| Call site | Logs success | Logs failure | Emits metric | Bubbles to UI |
+|---|---|---|---|---|
+
+---
+
+## Service-Level Override Findings
+
+[Rows from `services/*/service.yaml` parsing — env-var defaults that fall back to `dummy`, retry/timeout overrides that disable safety, URL/key drift between deployments]
+
+---
+
+## What This Audit Did Not Cover
+
+- FSM correctness and safety (run `/audit-fsm`)
+- Security review of credential handling, env-var injection, `eval`/`exec`, unsafe deserialization (run `/security-review`)
+- Dependency CVEs (run `pip-audit` / `safety check`)
+- Mathematical correctness of strategy / pricing logic
+- Smart-contract resilience (reentrancy, gas griefing, ordering attacks)
+- Network / load testing under sustained outage (this audit is static)
+- [Add scope exclusions specific to this run, e.g. "service.yaml overrides not parsed because no services/ directory in scope"]
 ```
 
 ### Priority Assignment Rules
@@ -695,15 +969,29 @@ Before finalizing the report, verify:
 - [ ] Every failure path is traced through to the FSM outcome (including composed FSM)
 - [ ] Every unhandled exception path is identified (check exception hierarchies carefully!)
 - [ ] The `JSONDecodeError` vs `RequestException` distinction is checked everywhere `response.json()` is called in a `RequestException` except block
+- [ ] BP1 pre-flag reminder applied — verified `except` clauses do NOT include `ValueError` before flagging
 - [ ] The `{"data": null}` pattern is checked everywhere `.get("data", {})` is used
 - [ ] The `Subgraph.process_response` override is checked for `None` error message handling
 - [ ] All fallback/cached values are cataloged with their staleness risk
-- [ ] All retry strategies are documented and compared
+- [ ] All retry strategies are documented and compared (CC1)
 - [ ] Thread blocking and timeout risks are documented (including third-party library internals)
 - [ ] Third-party httpx/requests clients are checked for missing timeouts
 - [ ] `MAX_WORKER_THREADS` and executor deduplication risks are documented
 - [ ] Pre-FSM handler crashes are checked (accessing synchronized_data before FSM starts)
 - [ ] Connection `on_send` payload deserialization is checked for exception handling
+- [ ] **BP15** — every non-idempotent POST has its dedup mechanism documented (or flagged as P1)
+- [ ] **BP16** — `except` blocks decode retry eligibility via `isinstance` / status code, not substring match
+- [ ] **BP17** — every class-level `_VALID_*` / `_ALLOWED_*` constant is referenced from the dispatch path
+- [ ] **BP18** — `if X is None:` branches on fallible external calls do NOT default to optimistic state
+- [ ] **BP19** — no `verify=False`; no hardcoded credentials; no secrets in URL query strings
+- [ ] **BP20** — every paginated fetch documents partial-failure semantics
+- [ ] **BP21** — every external response with potentially unbounded size has a size cap
+- [ ] **BP22** — signed payloads with timestamps use consensus-safe time when in a multi-agent service
+- [ ] **CC8** — worst-case-blocking vs round_timeout computed for every call site
+- [ ] **CC9** — observability table built; rows that are mostly ✗ on failure are flagged
+- [ ] `services/*/service.yaml` overrides parsed and resilience-relevant changes flagged
+- [ ] Data-type trace performed before flagging type-mismatch findings (Methodology Guardrails)
 - [ ] The crash/stuck/side-effect classification is complete
 - [ ] The priority matrix covers every finding
 - [ ] Each fix description is specific enough to implement directly
+- [ ] Report includes "What this audit did not cover" section

--- a/claude-skills/audit-resilience/SKILL.md
+++ b/claude-skills/audit-resilience/SKILL.md
@@ -584,7 +584,11 @@ The external dependency returned "unknown" (RPC down, response malformed). The h
 
 Grep-level checks. Each finding is independent; flag every match.
 
-- **`verify=False`** on `requests.*` / `httpx.*` / `aiohttp.*` — disables TLS certificate verification, opens MITM. Search: `verify=False`, `verify = False`, `ssl=False`, `ssl_context=None` in HTTP-call sites.
+- **TLS verification disabled** on `requests.*` / `httpx.*` / `aiohttp.*` — disables certificate verification, opens MITM. Dangerous forms to search for:
+  - `requests` / `httpx`: `verify=False` (also `verify = False`)
+  - `aiohttp`: `ssl=False`, OR a custom `ssl.SSLContext(...)` passed in with `check_hostname = False` and/or `verify_mode = ssl.CERT_NONE`
+  - `ssl.create_default_context()` followed by attribute mutations that disable verification
+  - Do NOT flag `ssl_context=None` — this is the `httpx.Client` / `httpx.AsyncClient` default and means "use the system default SSL context," which validates against the trust store. Grepping for `ssl_context=None` surfaces every explicit-default usage as a false positive.
 - **API keys / tokens hardcoded as string literals** — search for assignment patterns: `api_key\s*=\s*"`, `token\s*=\s*"`, `secret\s*=\s*"`, `Bearer ` literal. Cross-reference against `.gitleaks` output if available.
 - **Secrets in URL query strings** — `?apikey=`, `?token=`, `?api_key=`, `?key=` — these end up in HTTP server logs, proxy logs, and browser histories. Headers are safer.
 - **`set_api_creds` failure paths** — when credential setup can fail (e.g. `client.create_or_derive_api_key()`), is the connection gracefully marked unusable, or does it silently allow unauthenticated traffic? Trace from the credential-setup call to the first request.

--- a/claude-skills/audit-resilience/SKILL.md
+++ b/claude-skills/audit-resilience/SKILL.md
@@ -718,6 +718,23 @@ Past examples worth flagging by name: trader's `trader_pearl/` (Omenstrat) vs `p
 
 These guardrails reduce false positives observed in prior runs. Apply them before flagging any finding.
 
+### Verify every sub-agent finding before accepting it
+
+The Step B analysis agents return **candidate** findings with **candidate** severities, not final ones. The spawning agent (you) MUST hand-verify each candidate against the source before promoting it into the report. Sub-agents over-report because they lack the cross-cutting view.
+
+For each candidate finding, before accepting:
+
+1. **Read the cited `file:line` in the actual source.** Confirm the bug exists as described — not a misread, not a paraphrase that drifts from the code, not a citation pointing at the wrong line.
+2. **Confirm the bug is real.** Apply the data-type trace guardrail (below). Apply the verbatim BP1 reminder (below). Re-check exception hierarchies and `except` clause widths personally.
+3. **Re-evaluate severity.** Sub-agents systematically over-classify. Concretely:
+   - "Unused / dead config" (defined-but-unenforced allowlist, vestigial constant) is **L**, not P0/P1, unless removing it actively enables an attack.
+   - A `verify=False` in a test fixture or development helper is **not P0** even though the regex matches.
+   - "JSONDecodeError uncaught" inside an `except ValueError` block is **not a finding** (BP1 false positive).
+4. **Consolidate split findings.** If three sub-agent findings point at one root cause (e.g. three separate P0s that all stem from one missing timeout in a third-party library wrapper), report ONCE at the appropriate priority, not three times.
+5. **Demote liberally.** If you can't reproduce the sub-agent's reasoning from the source in under a minute, the finding is probably wrong — drop it or downgrade to P3/P4 with an "informational" note.
+
+Sub-agent classification is input, not output. The report is your judgment, not the union of sub-agent outputs.
+
 ### Force the data-type trace before flagging
 
 When a check requires reasoning about a value's runtime type (BP1 dispatch, BP2 null guards, "type X passed where Y expected" claims), reason about the **runtime** type, not the static annotation. In open-autonomy, payload fields and DB-backed properties are JSON-deserialized — the runtime type may differ from the annotation.

--- a/claude-skills/audit-resilience/SKILL.md
+++ b/claude-skills/audit-resilience/SKILL.md
@@ -631,7 +631,8 @@ Signed orders, EIP-712 typed data, relayer transactions, and many exchange APIs 
 1. Find call sites that build a signed payload for an external counterparty: relayer / exchange POSTs, EIP-712 messages, signed orders.
 2. Inspect how the payload's `timestamp` / `nonce` / `expiry` is computed.
    - `time.time()` / `datetime.now()` → drift-prone, **NOT consensus-safe** in a multi-agent service.
-   - `last_round_transition_timestamp` from `synchronized_data` → consensus-safe (it is the agreed block time, not an agent-local timestamp).
+   - `self.context.state.round_sequence.last_round_transition_timestamp` (a property on `RoundSequence`, NOT on `BaseSynchronizedData` — it is the agreed Tendermint block time of the last transition) → consensus-safe.
+   - A timestamp field written into a payload by a predecessor round and read via `synchronized_data` → consensus-safe.
 3. Verify the agent's NTP / clock-sync mechanism if `time.time()` is used. Document the deployment expectation.
 
 **Note:** this intersects with `audit-fsm` C5 (determinism in `end_block`). A timestamp produced in `end_block` must come from `synchronized_data`, not `time.time()`.

--- a/claude-skills/security-review/SKILL.md
+++ b/claude-skills/security-review/SKILL.md
@@ -1,0 +1,736 @@
+---
+name: security-review
+description: Security review of an open-autonomy agent service — cryptographic key handling, dynamic code execution, ABCI authentication and replay, secret exposure, dependency supply chain, and deployment hardening
+argument-hint: "[path/to/skill or packages/ or service/]"
+disable-model-invocation: false
+---
+
+# Security Review Skill
+
+You are an expert security reviewer for **open-autonomy** agent services. Your job is to identify security vulnerabilities specific to multi-agent autonomous services: cryptographic key handling, dynamic code execution paths, ABCI authentication and replay, secret exposure, configuration-driven RCE, dependency supply chain, and deployment hardening.
+
+Open-autonomy is a Python framework for creating decentralized multi-agent systems. Source and docs: https://github.com/valory-xyz/open-autonomy
+
+This skill is **complementary** to the other audit skills:
+
+- `/audit-fsm` — FSM correctness and safety. If a finding is about consensus correctness or round logic, cite the relevant audit-fsm check ID instead of duplicating here.
+- `/audit-resilience` — external request resilience (timeouts, retries, idempotency). If a finding is about HTTP-level robustness, cite that skill.
+
+Security findings that overlap with those skills (e.g. logging private keys overlaps with audit-fsm L4) should be reported here at higher severity if the impact is **disclosure** rather than operational, and cite the cross-reference.
+
+## How to Use Arguments
+
+- If `$ARGUMENTS` is provided, audit only those paths (e.g. `packages/valory/skills/transaction_settlement_abci`)
+- If `$ARGUMENTS` is empty, audit the whole repo: `packages/`, `autonomy/`, `plugins/`, `services/`, `customs/` (if present), and deployment artifacts (`Dockerfile*`, `docker-compose*`, `*.yaml` configs)
+- Multiple paths can be space-separated
+
+---
+
+## Open-Autonomy Security Architecture Reference
+
+This section encodes the threat model. Use it as ground truth — do not rely on external documentation.
+
+### Cryptographic Key Lifecycle
+
+Open-autonomy agents hold private keys for one or more chains. Default file locations:
+- `ethereum_private_key.txt`
+- `solana_private_key.txt`
+- `cosmos_private_key.txt`
+
+Loaded by `aea` core via `KeyManager` at startup. Used for:
+- Signing ABCI payloads (each agent's `sender` field on consensus payloads)
+- Signing on-chain transactions to a Gnosis Safe (multi-sig) or directly to a contract
+- Establishing ACN (Agent Communication Network) identity
+- Tendermint validator keys (separate, in `priv_validator_key.json`)
+
+**Threat surface:**
+- **Build-time leakage**: key file in container image layer, build artifact, or git history → permanent compromise.
+- **Runtime leakage**: key value in env var → visible via `docker inspect`, `/proc/<pid>/environ`, supervisor logs.
+- **Logging leakage**: key in log line → propagates to log aggregators, on-disk logs, error tracking, kept indefinitely.
+- **Network leakage**: key in payload broadcast over Tendermint → all peers and validators see it; in HTTP response from agent UI / debug endpoint → exposed to anyone with network access; in error message returned to RPC caller.
+- **Key derivation leakage**: mnemonic / seed / entropy logged or returned.
+
+A leaked agent key generally allows:
+- Submitting valid ABCI payloads as that agent
+- Co-signing Safe transactions (in a 1-of-N or quorum-met scenario)
+- Exhausting the agent's gas budget on chain
+- Impersonating the agent in ACN
+
+### ABCI Authentication and Replay Model
+
+ABCI payloads carry `sender: str` (agent address). The framework verifies via Tendermint signature that the payload was signed by the claimed sender. The round then verifies:
+- `sender` is in the active participant set
+- Payload type matches the round's `payload_class`
+- Threshold rules (e.g. `CollectSameUntilThresholdRound` requires N agents to agree)
+
+**What is NOT verified by the framework:**
+- **Payload field semantics**: an agent reporting "I have 1 ETH" is not cross-checked against actual on-chain balance. Field-level validation is the round/behaviour author's responsibility.
+- **Cross-period replay**: a serialized payload from period N can in some cases be re-submitted in period M; the round_id and any nonce are the only protection. If the round_id repeats (likely after a reset cycle) and no per-period nonce is bound, replay is possible.
+- **Source authenticity beyond AEA identity**: if an agent's key is stolen, the attacker is indistinguishable from the legitimate agent. There is no per-payload TOFU or out-of-band confirmation.
+- **Payload class identity stability**: `_MetaPayload` keys payloads by `"{module}.{ClassName}"`. Renaming the payload class or moving its module breaks deserialization of persisted Tendermint state — and creates a window where two distinct payload types share a registry key during rollout. (Cross-reference: audit-fsm gap #4.)
+
+### IPFS-Loaded Strategy Model (`customs/`)
+
+Strategies under `customs/` (e.g. `kelly_criterion`, `fixed_bet`) are loaded by IPFS hash at runtime:
+
+1. The hash is configured in `aea-config.yaml` / `service.yaml` — typically as a param like `FILE_HASH_TO_STRATEGIES` mapping IPFS hashes to strategy module names.
+2. Code is fetched from IPFS, the content hash is verified against the configured hash, and the module is **executed in the agent process**.
+
+**Trust boundary:** the configured hash is the only thing standing between the agent and arbitrary code execution. The strategy code runs with full agent privileges:
+- Access to private keys via `KeyManager`
+- Access to environment variables
+- Network access to all configured endpoints (RPC, exchange APIs, IPFS)
+- Ability to read/write `synchronized_data` (consensus-critical state)
+
+**Threat surface:**
+- A wrong hash (typo, misconfiguration, malicious config injection) → agent fetches and executes attacker-chosen code.
+- A hash that points to legitimate code today but was uploaded by a third party → if the IPFS pinning service or attacker controls the hash, the agent runs whatever the hash resolves to.
+- Strategy loaded but not validated for type contracts → strategy can mutate global state in surprising ways (e.g. monkeypatch `Web3.eth.send_raw_transaction`).
+
+### Configuration / Env-Var Resolution
+
+`skill.yaml`, `aea-config.yaml`, `service.yaml` support env-var interpolation:
+
+```yaml
+api_url: ${API_URL:str:https://default.example}
+api_key: ${API_KEY:str:dummy}
+```
+
+Resolution happens at agent startup. Resolved values flow into `Params` / `Model` instances and are read at runtime by behaviours.
+
+**Threat surface:**
+- **`dummy` / empty defaults in production**: if the env var isn't set, the agent runs with the placeholder. Anonymous requests to authenticated endpoints, wrong addresses, "test" keys.
+- **Env-vars in `docker-compose.yaml` checked into git**: anyone with read access to the repo has the secret.
+- **Env-vars baked into container image layers**: `ENV API_KEY=...` in a Dockerfile persists in the image even if overridden at runtime.
+- **Env-var values flowing into `subprocess` / shell calls** without sanitization: command injection.
+- **Env-var values used as Python module paths** (`importlib.import_module(os.environ['MODULE'])`): RCE.
+
+### Tendermint Network Surface
+
+Each agent ships with a Tendermint sidecar:
+- RPC port (default 26657) — used for ABCI queries, block info, broadcast
+- P2P port (default 26656) — peer-to-peer consensus
+- gRPC port (default 9090, optional)
+
+**Threat surface:**
+- RPC exposed on `0.0.0.0` instead of localhost / agent network → external read of all consensus state
+- P2P open to internet without persistent peers list → DOS amplification, sybil resistance compromised
+- Tendermint validator key (`priv_validator_key.json`) misplaced or world-readable → consensus signature forgery
+
+### Container / Deployment Threat Surface
+
+`autonomy deploy build` produces docker-compose / k8s manifests. Common defaults:
+- Tendermint and agent processes run as **root** in container unless overridden
+- Keys mounted via volume from host
+- Logs written to mounted volume
+- Health/debug endpoints potentially exposed (e.g. Flask Tendermint monitor on port 8080)
+
+**Threat surface:**
+- Root container = container escape → host compromise has broader blast radius
+- World-readable mounted key file
+- Health endpoint that returns synced state, validator info, or agent address without auth
+- Debug routes that expose internal state in production builds
+
+### Dependency Supply Chain
+
+Open-autonomy uses `poetry` / `pipenv` and `tomte` for tooling. License policy (per `CLAUDE.md`):
+- Allowed: MIT, BSD, Apache 2.0
+- Prohibited: GPL, LGPL, MPL
+
+Third-party trading libraries (`py_clob_client`, `web3`, `httpx`, `requests`, exchange-specific clients) are full-trust runtime deps with full keychain access.
+
+**Threat surface:**
+- Pinned dep with a known but unpatched CVE
+- Typosquat (e.g. `python-requests` vs `requests`, `crpytography` vs `cryptography`)
+- Transitive dep without pinning → lockfile drift across CI / dev / prod
+- Dev-only dep bleeding into prod (`bandit`, `safety` in runtime container)
+- Compromised release of an upstream package (rare but high-impact)
+- Unsigned source distribution where wheel is unavailable
+
+The repo's `tox -e safety` allowlist already pins known-unfixed CVEs in transitive deps. Audit the allowlist itself.
+
+---
+
+## Audit Checklist
+
+### Critical (C) — Immediate compromise (RCE, key disclosure, full agent takeover)
+
+#### C1: Dynamic Code Execution on Untrusted Input
+
+**What:** `eval`, `exec`, `compile`, or dynamic import where the input is not statically known. Untrusted input includes anything sourced from: HTTP request, ABCI payload, env var, file content, IPFS, external API response.
+
+**Search patterns:**
+- `eval(`, `exec(`, `compile(` — any usage in `packages/`, `customs/`, `autonomy/`
+- `importlib.import_module(`, `__import__(` with non-literal arguments
+- `pickle.load`, `pickle.loads` on data not produced by the same trust boundary (file written by user, network response, IPFS payload)
+- `marshal.loads`, `shelve.open` on untrusted data
+- `yaml.load(` (without `Loader=SafeLoader`) — defaults to `FullLoader` which can construct arbitrary Python objects in older PyYAML versions
+- `subprocess.*` with `shell=True` AND interpolated arguments (`f"cmd {var}"`, `"cmd " + var`, `cmd % var`)
+- `os.system(` with interpolated arguments
+- `Template(...).substitute(...)` where the template itself comes from untrusted input
+
+**Bug example:**
+```python
+# BUG: payload field interpolated into shell
+def process_strategy(self, payload):
+    strategy = payload.strategy_name
+    subprocess.run(f"python -m {strategy}", shell=True)  # RCE
+```
+
+**Fix:** never `eval`/`exec`; use `yaml.safe_load`; use `subprocess.run([cmd, arg1, arg2], shell=False)`; for pickle, sign and verify or replace with JSON.
+
+**Severity escalation:** If the input source is an ABCI payload or IPFS content, this is **unconditionally Critical** — a single malicious / compromised peer can pivot to RCE on every agent.
+
+#### C2: Private Key Disclosure
+
+**What:** Any code path that emits, persists, or returns a private key, mnemonic, seed, or signing material outside the `KeyManager` boundary.
+
+**Search patterns:**
+- Variable name regex inside `logger.*`, `print(`, `return`, response builders, payload constructors:
+  - `private_key`, `priv_key`, `pk`, `sk`, `secret`, `seed`, `mnemonic`, `entropy`, `signing_key`, `wallet.private_key`
+- HTTP handlers that read from `KeyManager` and return values in the response body (debug endpoints in particular)
+- Behaviours that interpolate signed material into `payload` fields broadcast over Tendermint
+- Files written by the agent that contain key material (`open(..., 'w')` with key in body)
+- Exception handlers that include the key in the error message (`raise ValueError(f"Bad key: {key}")`)
+- `__repr__` / `__str__` of wallet / signer objects that includes the key
+
+**Bug example:**
+```python
+# BUG: full HTTP response body logging includes Authorization header containing the agent key
+self.context.logger.info(f"Sent: {request}, Got: {response.json()}")
+# request includes signed message that derives from the private key
+```
+
+**Cross-reference:** audit-fsm L4 covers this at the operational level. /security-review escalates to Critical because the impact is permanent disclosure.
+
+**Fix:** never log key material; redact in `__repr__`; constrain key access to a single module that exposes only `sign(...)` not `get_key()`; review every debug endpoint.
+
+#### C3: IPFS Strategy Hash Trust Bypass
+
+**What:** Code paths that load Python modules from IPFS without hash verification, OR that allow the configured hash to be derived at runtime from untrusted input.
+
+**Search patterns:**
+- IPFS fetch + `importlib` / `exec` / `compile` of fetched bytes
+- `FILE_HASH_TO_STRATEGIES` (or similar param) populated from external source rather than static config
+- `customs/` loader code that fetches and evaluates without hash check
+- Hash configured via env var that defaults to placeholder (`dummy`, empty) — production agents may run with unverified strategy
+
+**Threat:** the IPFS hash IS the trust boundary. Bypassing it = arbitrary code execution with full agent privileges (keys, network, on-chain authority).
+
+**Fix:** statically configure hashes; verify content hash matches configured hash before executing; reject placeholder defaults in production builds.
+
+#### C4: Unsafe Deserialization on ABCI / Network Boundary
+
+**What:** Connection / handler code that deserializes inbound payloads using formats that allow code execution (`pickle`, `yaml.load`, `marshal`).
+
+**Search patterns:** in `connections/*/connection.py`, `handlers.py`, ABCI message handlers:
+- `pickle.loads(message.body)`, `pickle.loads(srr_message.payload)`
+- `yaml.load(...)` without `Loader=SafeLoader`
+- `marshal.loads(...)`
+- Custom deserializers that `eval` field values
+
+**Cross-reference:** audit-resilience BP14 covers `json.loads` exception handling at the connection boundary. /security-review C4 covers the harder issue: even if exception handling is correct, using a code-executing deserializer on network input is RCE waiting to happen.
+
+**Fix:** use JSON; if a binary format is needed, use protobuf / msgpack with strict schemas.
+
+#### C5: Hardcoded Secrets in Source Tree
+
+**What:** API keys, JWTs, mnemonics, private keys, OAuth tokens, AWS credentials, or webhook URLs with embedded tokens, committed in source.
+
+**Tooling:** `tox -e gitleaks` runs in CI. /security-review re-runs and reviews:
+- The current `gitleaks.toml` allowlist for over-broad patterns
+- New files added in the audit scope
+- Test fixtures that may have been accidentally promoted to runtime code paths
+
+**Search patterns** beyond gitleaks defaults. Gitleaks's built-in rules already cover common SaaS / cloud token shapes (Slack, GitHub, GitLab, AWS, Stripe, JWT, OpenAI, etc.) — do NOT re-list those literals here, listing them would re-trigger gitleaks on this file. Audit-specific additions:
+- `0x[a-fA-F0-9]{64}` (Ethereum private key shape) in non-test files
+- `mnemonic = "..."`, mnemonic-shaped 12/15/18/21/24-word strings in source
+
+**Severity:** Critical regardless of intent — once committed, must be assumed compromised even after removal (git history retention).
+
+**Fix:** rotate the disclosed credential; remove from history (`git filter-repo`); replace with env-var or secrets-manager reference; add to `gitleaks.toml` as a tested negative.
+
+#### C6: Command Injection via Shell-Subprocess Interpolation
+
+**What:** `subprocess.*(..., shell=True)` or `os.system(...)` where any argument is composed from external input (env var, payload field, HTTP query param, file content).
+
+**Search patterns:**
+- `subprocess.run(`, `subprocess.call(`, `subprocess.Popen(` with `shell=True`
+- `os.system(`, `os.popen(`
+- `commands.getoutput(` (if Python 2 legacy), `pty.spawn(`
+
+For each, check whether arguments are static literals or interpolated.
+
+**Bug example:**
+```python
+# BUG: agent_id from HTTP request flows into shell
+@app.post("/restart")
+def restart(agent_id: str):
+    subprocess.run(f"systemctl restart agent-{agent_id}", shell=True)
+```
+
+**Fix:** `shell=False` and pass argv as a list; use `shlex.quote` for unavoidable shell paths; validate via allowlist before interpolation.
+
+---
+
+### High (H) — High-impact issues short of immediate RCE
+
+#### H1: Env-Var-Driven Authentication with Insecure Defaults
+
+**What:** `service.yaml` / `aea-config.yaml` / `skill.yaml` with env-var-interpolated auth credentials whose default is `dummy`, empty string, or a placeholder. Production deployments depend on the env var being set; if it isn't, the agent runs unauthenticated or with shared known-bad credentials.
+
+**Search patterns** in YAML configs:
+- `${[A-Z_]+:str:dummy}`, `${[A-Z_]+:str:}`, `${[A-Z_]+:str:test}`, `${[A-Z_]+:str:placeholder}`
+- Param names matching `*_api_key`, `*_token`, `*_secret`, `*_password`, `*_credential`
+- Param names matching `*_url`, `*_endpoint` where placeholder is suspicious (`localhost`, `example.com`)
+
+**Fix:** require env var (no default), or default to a value that **fails closed** (e.g. an unauthenticated client that only allows read-only ops); add a startup check that refuses to run with placeholder values in production mode.
+
+#### H2: Hardcoded Secrets in Deployment Artifacts
+
+**What:** Secrets in `docker-compose.yaml`, `Dockerfile*`, `kubernetes.yaml`, `helm/` charts, GitHub Actions workflows, or `.env*` files committed to the repo.
+
+**Search patterns:**
+- `Dockerfile*`: `ENV API_KEY=`, `ARG SECRET=`, `RUN echo "..." > /key`
+- `docker-compose.yaml`: literal values in `environment:` blocks (vs `${VAR}` references)
+- `.github/workflows/*.yml`: literal tokens (vs `${{ secrets.X }}`)
+- `.env`, `.env.local`, `.env.production` committed to git (these should be in `.gitignore`)
+- `kubernetes/*.yaml`: `data:` blocks with base64-encoded plaintext (Secret manifests)
+
+**Fix:** use Docker secrets / Kubernetes Secret resources with mounted files; use GitHub Actions encrypted secrets; ensure `.env*` is gitignored; rotate any value found.
+
+#### H3: Container Running as Root
+
+**What:** Dockerfiles without a `USER` directive, or with `USER root`, leave the agent process running as root inside the container.
+
+**Search patterns:** `Dockerfile*`, especially `deployments/Dockerfiles/*/Dockerfile`:
+- Absence of `USER` directive (Docker default = root)
+- `USER root` explicitly set
+- `RUN chown -R root:root /app` patterns
+
+**Why high not critical:** root-in-container isn't immediate RCE on the host, but combined with any container-escape CVE (e.g. cgroup vulnerabilities, kernel bugs), the blast radius is much larger than non-root.
+
+**Fix:** create a non-root user (`adduser --system --no-create-home agent`), `USER agent`, ensure mounted key files are readable by that uid only.
+
+#### H4: Tendermint RPC Exposed Beyond Local Network
+
+**What:** Tendermint RPC port (default 26657) bound to `0.0.0.0` or exposed in `docker-compose.yaml` `ports:` section without auth.
+
+**Search patterns:**
+- `docker-compose*.yaml`: `ports:` entries that publish 26657 / 26656 to the host
+- Tendermint config (`config.toml`): `laddr = "tcp://0.0.0.0:26657"` instead of `tcp://127.0.0.1:26657`
+- Kubernetes Service manifests with `type: LoadBalancer` for Tendermint
+
+**Threat:** Tendermint RPC exposes block data, validator info, mempool state, and (in some configurations) `broadcast_tx_*` endpoints that allow anyone to submit transactions.
+
+**Fix:** bind to localhost or to the agent-internal network; use a network policy / firewall to restrict ingress; require auth proxy for any external RPC access.
+
+#### H5: ABCI Payload Field Validation Gaps
+
+**What:** Payload fields read by `end_block()` or `process_payload()` that are used in security-sensitive contexts (signing material, addresses, amounts, contract addresses, URLs) without explicit validation.
+
+**Search patterns:**
+- Round / behaviour code that reads `payload.<field>` and uses it for: `Web3.toChecksumAddress(...)`, `Account.sign_message(...)`, contract write calls, HTTP requests to user-controlled URLs
+- Payload classes whose fields are typed as `str` or `Any` (no Pydantic / dataclass-validation hooks)
+
+**Threat scenario:** a compromised agent submits a payload with a malicious URL, address, or amount. If the round accepts the payload without bounds-checking, the consensus value drives downstream actions across all agents.
+
+**Fix:** validate at `check_payload()` (round side) and at payload construction (behaviour side); use strict type hints (`Address`, `URL`, `PositiveInt`); reject out-of-range values.
+
+#### H6: Replay Protection Gaps
+
+**What:** Round / payload designs that lack a per-period nonce and could be replayed across periods if the same agent re-submits a previously seen payload.
+
+**How to check:**
+1. For each `payload_class`, list its fields. Is there a per-period nonce, period_count, or `last_round_transition_timestamp`?
+2. If not, can a payload from period N be re-submitted in period M with the same effect?
+3. For payloads that drive on-chain transactions, does the resulting tx include the chain-id, contract nonce, and Safe nonce?
+
+**Threat:** an attacker (or a buggy resubmission) replays a payload to trigger a duplicate financial action. (Cross-reference: audit-resilience BP15 covers idempotency on retry; H6 here is the consensus-level analogue.)
+
+**Fix:** include `period_count` or a per-round nonce in every payload that drives state-changing actions; verify on the round side.
+
+#### H7: Dependency CVEs
+
+**What:** Run `tox -e safety` (which uses tomte's allowlist) and `pip-audit` against the resolved environment. Each unaddressed CVE in a runtime dep is a finding.
+
+**Process:**
+1. Run `tox -e safety` and `pip-audit -r <lockfile>` (or directly against the venv).
+2. For each CVE not in the allowlist, document: package, version, CVE ID, severity per upstream, exploitability in this codebase (does the agent reach the vulnerable code path?).
+3. Audit the existing tomte allowlist (`-i 37524 -i 38038 ...` in `tox.ini`) — for each pinned CVE, check whether upstream has shipped a fix that allows the pin to be removed.
+
+**Fix:** upgrade the dep; if upgrade is impossible, document the mitigation in the allowlist with a date and re-check quarterly; for unreachable CVEs, document why they don't apply.
+
+---
+
+### Medium (M) — Hardening gaps and weak validation
+
+#### M1: World-Readable Key Files in Container
+
+**What:** Mounted private-key files with permissive mode (`0644`, `0755`), or container-internal copies created without chmod.
+
+**Search patterns:**
+- `Dockerfile*`: `COPY ethereum_private_key.txt` without subsequent `RUN chmod 600`
+- `docker-compose*.yaml`: volume mounts of key files without explicit `read_only: true`
+- Setup scripts that `cp` keys without chmod 600
+- Kubernetes Secret mounts with `defaultMode: 0644`
+
+**Fix:** `chmod 600 *_private_key.txt` after copy / mount; use Kubernetes Secret `defaultMode: 0400`; mount read-only.
+
+#### M2: Debug / Health Endpoints Exposing Internal State
+
+**What:** Flask Tendermint monitor (port 8080), agent debug routes, or health endpoints that return more than `{"status": "ok"}` — e.g. agent address, validator info, signed-payload count, configured params, last block.
+
+**Search patterns:**
+- `flask.*route(`, `@app.route(`, `@app.get(`, `@app.post(` in `packages/`, `autonomy/`, `deployments/`
+- `make_response(`, `jsonify(` returning rich structures
+- Response bodies that include `synchronized_data`, `params`, `address`, `validator`
+
+**Threat:** reconnaissance for a targeted attack. Validator addresses + chain → fund tracing; configured RPCs → MITM target list; agent address → on-chain identity disclosure.
+
+**Fix:** strip non-essential fields from health responses; gate debug routes behind `DEBUG=true` env var; require auth for any internal-state endpoint.
+
+#### M3: Weak Validation at HTTP Handler Trust Boundaries
+
+**What:** HTTP handlers in `handlers.py` that accept request bodies without schema validation. Audit-resilience covers crash patterns; /security-review M3 covers exploitability:
+- SQL injection in any backing store query (rare in agents but check)
+- Path traversal in any handler that reads/writes files based on request input (`open(f"data/{request.name}.json")`)
+- SSRF in any handler that makes outbound requests to URLs from the request (`requests.get(request.url)`)
+- XXE if XML parsing is used without `defusedxml`
+
+**Search patterns:**
+- `open(` with interpolated path component
+- `requests.get(...)` with URL from request
+- `xml.etree.ElementTree.parse(`, `lxml.etree.parse(` without `defusedxml`
+- f-strings or `.format()` building SQL queries
+
+**Fix:** validate inputs against a whitelist; resolve and check filesystem paths (`Path(...).resolve().is_relative_to(allowed_root)`); disallow user-controlled outbound URLs or restrict to allowlisted hosts; use `defusedxml.ElementTree`.
+
+#### M4: Cryptographic Weakness
+
+**What:**
+- MD5 / SHA1 used for security purposes (signatures, MACs, password hashing)
+- Hardcoded IVs / nonces in encryption
+- ECB mode block ciphers
+- `random.*` for security-critical randomness (use `secrets`)
+- Custom HMAC implementations (use `hmac.compare_digest` for comparison)
+
+**Search patterns:**
+- `hashlib.md5(`, `hashlib.sha1(` — flag if used in `verify`, `auth`, `sign`, `mac` contexts
+- `Crypto.Cipher.AES.MODE_ECB`, `AES.new(..., AES.MODE_ECB, ...)`
+- `random.randint(`, `random.choice(`, `os.urandom(` (the latter is OK, but check usage) where the value is used as a key, IV, nonce, or token
+- `==` comparison of HMACs / signatures (timing attack)
+
+**Fix:** SHA-256+ for hashing; AES-GCM / ChaCha20-Poly1305 for encryption; `secrets.token_bytes(32)` for tokens; `hmac.compare_digest` for comparison.
+
+#### M5: Loose CORS / Missing Security Headers
+
+**What:** HTTP services (Flask Tendermint monitor, agent UI) with `Access-Control-Allow-Origin: *` or missing security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`, `Content-Security-Policy`).
+
+**Search patterns:**
+- `Access-Control-Allow-Origin` with `*`
+- `flask_cors.CORS(app)` with default config (= permissive)
+- Absence of header-setting middleware
+
+**Fix:** restrict CORS to known origins; set security headers via middleware; for read-only endpoints, document the threat model explicitly.
+
+#### M6: License Compliance Drift
+
+**What:** Per `CLAUDE.md`, only MIT / BSD / Apache 2.0 are allowed; GPL / LGPL / MPL are prohibited. Dependency tree may include prohibited licenses transitively.
+
+**Process:**
+1. Run `pip-licenses --format=markdown` (or `tomte`'s license tooling if available) against the resolved environment.
+2. Flag any dep with GPL / LGPL / MPL / AGPL / SSPL / proprietary license.
+3. Audit copyleft creep in transitive deps.
+
+**Fix:** replace the dep; add explicit exception with legal review; document in NOTICE / SBOM.
+
+---
+
+### Low (L) — Defense in depth and observability
+
+#### L1: Missing Secrets-in-Logs Redaction Policy
+
+**What:** Audit-fsm L4 covers individual log-line leaks. /security-review L1 escalates to the systemic level: is there a redaction layer in the logging pipeline, or does every author bear the burden individually?
+
+**How to check:**
+- Look for a centralized log filter / formatter that redacts secret-shaped strings
+- Check whether `logging.config.dictConfig(...)` includes a `RedactingFormatter` or similar
+- Check whether sensitive fields are dropped at the structured-log boundary (e.g. via `structlog` processors)
+
+**Fix:** add a redacting formatter that masks Ethereum-key-shaped strings, JWTs, Bearer tokens, and any field name in a configurable allowlist.
+
+#### L2: No Startup-Time Secret-Validation Check
+
+**What:** Even with H1 fixed (no insecure defaults), there's value in a startup check that asserts every required secret env var is set and matches an expected shape (e.g. `API_KEY` must be 32+ chars, `PRIVATE_KEY` must be 64 hex chars).
+
+**Fix:** add a `validate_secrets()` call at agent startup; fail fast with a clear error if a required secret is missing or malformed.
+
+#### L3: Tendermint Persistent Peer List Hardcoding
+
+**What:** `persistent_peers` configured statically rather than via service discovery. Not a vulnerability per se, but limits the network's resilience to peer churn.
+
+**Fix:** documented as informational; consider DNS-based or registry-based peer discovery for production.
+
+#### L4: SBOM / Build Provenance
+
+**What:** Are container images built with reproducibility / SBOM attestation? Are wheels installed from a verified PyPI mirror? Is the build pipeline signed?
+
+**Fix:** generate SBOM via `cyclonedx-py` or `syft`; sign images with `cosign`; pin to an internal index where possible.
+
+#### L5: Audit-Log Coverage of Security-Sensitive Events
+
+**What:** Are key operations (key-file load, on-chain tx submission, ABCI payload signing, strategy load, config-reload) recorded to a separate audit log distinct from operational logs? Without this, post-incident forensics is hard.
+
+**Fix:** route security events to a dedicated logger / external audit sink; include timestamp, agent id, operation, outcome.
+
+---
+
+## False Positive Guidance
+
+These patterns look suspicious but are **correct by design**. Do NOT report them:
+
+### Test-fixture private keys
+Test fixtures (`tests/`, `plugins/aea-test-autonomy/`, `conftest.py`) routinely include hardcoded test private keys for deterministic test setup. These are well-known throwaway keys used by Hardhat / Ganache / test Tendermint. Do NOT flag these as C5. Limit C5 to non-test code paths.
+
+### Dummy / placeholder values in *test* config files
+Test YAML configs (`tests/test_data/`, `aea-test-autonomy` fixtures) use placeholder URLs / keys / addresses for hermetic testing. Don't flag these as H1 — they aren't deployed.
+
+### `pickle.loads` of internally-produced data
+If a `pickle.loads` reads a file or buffer that the agent itself wrote in the same process or container (e.g. local cache restore), it is not RCE-exposed in the same way as network input. Reduce severity to High and note the trust assumption.
+
+### `subprocess.run(..., shell=False)` with interpolated args
+Argument interpolation is safe when `shell=False` because the shell isn't involved — argv is passed directly to `execve`. Don't flag these as C6. C6 requires `shell=True`.
+
+### `random.*` for non-security uses
+`random.choice` for jitter, log sampling, A/B test bucketing, etc. is fine. Limit M4 to uses where the output is a key, IV, nonce, token, password, or anything that protects a secret.
+
+### Internal RPC ports without auth
+Tendermint RPC bound to `127.0.0.1` or an internal Docker network without external publication is the framework's default and is OK. H4 only applies when the port is published to a host interface or routable network.
+
+### `eval(` in framework metaprogramming
+Some framework-internal code uses `eval` for limited purposes (e.g. `enum.Enum` value coercion in metaclass init). If the input is statically constructed inside the same module and not user-controlled, do not flag as C1. Verify the input source before flagging.
+
+### Hardcoded contract addresses in `customs/` / package_overrides
+Contract addresses are public on-chain. They are not secrets. Don't conflate with API keys.
+
+---
+
+## Methodology Guardrails
+
+These guardrails reduce false positives observed in prior audit runs.
+
+### Distinguish disclosure from exposure
+- **Disclosure** = the secret has left the trust boundary (in a log, response, payload, file outside the agent dir).
+- **Exposure** = the secret is reachable via a code path but not yet emitted (e.g. `KeyManager.get_key()` is callable from a behaviour).
+
+C2 is for disclosure. Exposure is M-level at most, often L (defense in depth). Don't over-escalate exposure to Critical.
+
+### Trace every "untrusted input" claim to a source
+For C1, C4, C6, M3 findings: name the **source** of the untrusted input (HTTP request body, ABCI payload field, env var, file content, IPFS payload). If you can't name it, downgrade or drop the finding.
+
+### Test code is in scope but with reduced severity
+Test files can leak secrets that get history-mirrored, can introduce supply-chain risks via test deps, and can mask production bugs. Audit them. But:
+- Hardcoded test keys: not a finding (see False Positive Guidance).
+- Dev-only deps: not a finding unless the dep is also imported in non-test code (`grep` to verify).
+- `eval` in test scaffolding: not a finding unless the eval input comes from a non-test surface.
+
+### Dual-skill findings
+If a finding fits audit-fsm or audit-resilience better, cite that skill's check ID and demote here. Examples:
+- "logger.info(f'key={k}')" → cite audit-fsm L4 first; /security-review C2 only adds the disclosure framing.
+- "no timeout on HTTP" → audit-resilience BP8/CC5 owns this; /security-review only flags if the timeout absence enables a security-relevant DOS or resource exhaustion.
+
+### Single-finding-per-bug
+If multiple checks (e.g. C1 RCE + H7 outdated dep + M4 weak crypto) flag the same root cause, report once with all relevant IDs cited.
+
+### Don't trust the static type
+Mirror of audit-fsm/audit-resilience methodology: fields annotated as `str` may be deserialized JSON whose runtime type differs. Trace the source before claiming a type-based safety property.
+
+---
+
+## Coverage Limitations
+
+This skill audits **agent-process security** in the open-autonomy codebase. The following are explicitly NOT covered — call this out in every report:
+
+- **Smart-contract security** (reentrancy, gas griefing, signature replay on chain) — out of scope; covered by Solidity-specific tooling (Slither, Mythril, manual audit).
+- **Cryptographic-library implementation review** — we trust `cryptography`, `eth_keys`, `web3.py` etc. as black boxes. CVEs in those libraries surface via H7.
+- **Tendermint internals** — we audit configuration, not the consensus engine.
+- **Network / load testing** under attack scenarios — this audit is static.
+- **Penetration testing of deployed services** — out of scope; recommend a separate engagement.
+- **Compliance** (SOC2, ISO 27001, GDPR) — this audit checks technical controls, not policy / process / documentation.
+- **Insider threat / multi-party governance** — out of scope.
+- **Physical security** of deployment hosts — out of scope.
+
+Companion skills:
+- `/audit-fsm` — FSM correctness and safety
+- `/audit-resilience` — external request resilience
+
+Include a "What this audit did not cover" section in every report.
+
+---
+
+## Analysis Procedure
+
+### Step 0: Run Existing Security Tools
+
+Before manual inspection, run the framework's tooling and capture the output:
+
+```bash
+# Bandit — static analysis for common Python security issues
+tox -e bandit
+
+# Safety — known CVEs in pinned dependencies (uses tomte allowlist)
+tox -e safety
+
+# Gitleaks — secrets scanning across history
+tox -e gitleaks
+
+# Or run all three in parallel
+make security
+```
+
+**Process the output:**
+- Bandit findings → cross-reference with the C/H/M checklist; many will already match (e.g. Bandit's `B602` ≈ C6, `B301` ≈ C4).
+- Safety findings → record under H7 with package, version, CVE ID; check the tomte allowlist for explanations.
+- Gitleaks findings → record under C5; for each, verify whether the secret is rotated.
+
+**Tooling-unavailable case.** If the tox envs cannot run (network restrictions, missing tomte version), note in the report and proceed with manual checks. Do NOT block the audit on tool availability.
+
+### Step 1: Static Discovery
+
+Launch up to **3 parallel Explore agents**, dividing the codebase:
+
+- **Agent 1 — code paths**: search `packages/`, `autonomy/`, `plugins/`, `customs/` for the C/H/M/L patterns above. For each match, capture file:line, the surrounding context, and the input source.
+- **Agent 2 — configuration**: parse `aea-config.yaml`, every `service.yaml`, every `skill.yaml` under audit. Extract env-var-interpolated params; flag insecure defaults (H1) and any param with security-relevant naming.
+- **Agent 3 — deployment**: read `Dockerfile*`, `docker-compose*.yaml`, `deployments/`, `kubernetes/` if present, and `.github/workflows/*.yml`. Flag root containers (H3), exposed RPC (H4), hardcoded secrets in deployment artifacts (H2), key-file permissions (M1).
+
+Each agent should return a structured list of candidates with check ID, file:line, and a short justification.
+
+### Step 2: Semantic Verification
+
+For each candidate from Step 1, an analysis agent:
+1. Reads the call site and surrounding context.
+2. Traces the input source for any "untrusted input" claim.
+3. Applies the False Positive Guidance.
+4. Promotes / demotes severity based on the actual blast radius.
+5. Produces a finding entry with code snippet, threat description, and concrete fix.
+
+### Step 3: Cross-Cutting Synthesis
+
+After per-finding analysis:
+1. Build a "Secrets Inventory" table: every credential / key / token surface, its storage mechanism, its rotation policy.
+2. Build a "Trust Boundaries" diagram-table: every input source that crosses a trust boundary (network, IPFS, env, file), with its validator (or absence thereof).
+3. Build a "Dependency Risk" table: every runtime dep, its license, its CVE status.
+4. Identify systemic patterns: e.g. "secrets are consistently set via env vars but no startup validation" → L2 finding cluster.
+
+### Step 4: Generate Report
+
+Merge all findings into the output format below.
+
+---
+
+## Output Format
+
+Present the security review as follows:
+
+```markdown
+# Security Review
+
+**Scope:** [list of audited paths / packages / services]
+**Date:** [current date]
+**Tools run:** bandit (Y/N), safety (Y/N), gitleaks (Y/N), pip-audit (Y/N)
+
+## Executive Summary
+
+- Critical findings: N
+- High findings: N
+- Medium findings: N
+- Low findings: N
+
+[2-3 sentences on the highest-impact findings and the systemic patterns they reveal]
+
+## Critical Findings
+
+### [C#]: [Title]
+- **File:** `path/to/file.py:line`
+- **Threat:** [what compromise this enables, who can trigger it]
+- **Code:**
+  ```python
+  [problematic code snippet]
+  ```
+- **Fix:**
+  ```python
+  [corrected code snippet]
+  ```
+- **Cross-references:** [audit-fsm L4 / audit-resilience BP14 / etc., if applicable]
+
+## High Findings
+[same format]
+
+## Medium Findings
+[same format]
+
+## Low Findings
+[same format]
+
+---
+
+## Secrets Inventory
+
+| Secret | Storage | Loaded by | Rotation policy |
+|---|---|---|---|
+| Ethereum private key | mounted volume | KeyManager | manual |
+| ... |
+
+## Trust Boundaries
+
+| Boundary | Input source | Validator | Findings |
+|---|---|---|---|
+| ABCI payload | Tendermint network | `check_payload()` per round | H5 if missing |
+| HTTP handler | external HTTP | per-handler `_validate_*` | M3 if missing |
+| IPFS strategy | IPFS network | content-hash check | C3 if missing |
+| Env-var config | host environment | none / startup check | H1 if defaulted |
+| ... |
+
+## Dependency Risk
+
+| Package | Version | License | CVE status |
+|---|---|---|---|
+| ... |
+
+## Tooling Output Summary
+
+### Bandit
+[counts by severity, top categories]
+
+### Safety
+[CVEs not in allowlist]
+
+### Gitleaks
+[hits, by file]
+
+---
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| Critical | N     |
+| High     | N     |
+| Medium   | N     |
+| Low      | N     |
+
+## What This Audit Did Not Cover
+
+- Smart-contract security (run Slither / Mythril / manual contract audit)
+- FSM correctness (run `/audit-fsm`)
+- External request resilience (run `/audit-resilience`)
+- Cryptographic-library internals (trust black boxes; CVEs surfaced via H7)
+- Tendermint consensus internals
+- Penetration testing of deployed services
+- Compliance audits (SOC2 / ISO 27001 / GDPR)
+- Insider threat / governance review
+- [Add scope exclusions specific to this run]
+```
+
+If no findings at a severity level, include the section header with "No findings." underneath.

--- a/claude-skills/security-review/SKILL.md
+++ b/claude-skills/security-review/SKILL.md
@@ -37,7 +37,7 @@ Open-autonomy agents hold private keys for one or more chains. Default file loca
 - `solana_private_key.txt`
 - `cosmos_private_key.txt`
 
-Loaded by `aea` core via `KeyManager` at startup. Used for:
+Loaded by `aea` core via `aea.crypto.wallet.Wallet` (and the underlying `CryptoStore`) at startup. Used for:
 - Signing ABCI payloads (each agent's `sender` field on consensus payloads)
 - Signing on-chain transactions to a Gnosis Safe (multi-sig) or directly to a contract
 - Establishing ACN (Agent Communication Network) identity
@@ -63,13 +63,18 @@ ABCI payloads carry `sender: str` (agent address). The framework verifies via Te
 - Payload type matches the round's `payload_class`
 - Threshold rules (e.g. `CollectSameUntilThresholdRound` requires N agents to agree)
 
+**What the framework DOES guarantee (do not re-report as findings against standard rounds):**
+- **Cross-period replay protection on standard rounds.** `BaseTxPayload.round_count` is monotonic and never resets across periods. The standard collection rounds (`CollectSameUntilThresholdRound`, etc.) verify it in `process_payload()` (`packages/valory/skills/abstract_round_abci/base.py:1417`): `if payload.round_count != self.synchronized_data.round_count: raise ABCIAppInternalError(...)`. A payload from a closed period therefore cannot be re-submitted in a later period as long as the round's `process_payload` invokes the parent's check.
+
 **What is NOT verified by the framework:**
 - **Payload field semantics**: an agent reporting "I have 1 ETH" is not cross-checked against actual on-chain balance. Field-level validation is the round/behaviour author's responsibility.
-- **Cross-period replay**: a serialized payload from period N can in some cases be re-submitted in period M; the round_id and any nonce are the only protection. If the round_id repeats (likely after a reset cycle) and no per-period nonce is bound, replay is possible.
+- **Cross-period replay on custom rounds that bypass the parent check.** Any round that overrides `process_payload()` without invoking the standard `round_count` verification re-opens the replay surface. This is the surface H6 audits.
 - **Source authenticity beyond AEA identity**: if an agent's key is stolen, the attacker is indistinguishable from the legitimate agent. There is no per-payload TOFU or out-of-band confirmation.
-- **Payload class identity stability**: `_MetaPayload` keys payloads by `"{module}.{ClassName}"`. Renaming the payload class or moving its module breaks deserialization of persisted Tendermint state — and creates a window where two distinct payload types share a registry key during rollout. (Cross-reference: audit-fsm gap #4.)
+- **Payload class identity stability**: `_MetaPayload` keys payloads by `"{module}.{ClassName}"`. Renaming the payload class or moving its module breaks deserialization of persisted Tendermint state — and creates a window where two distinct payload types share a registry key during rollout. Cross-reference: `audit-fsm` M1 (`Payload Class Mismatch`) and T6 (`_MetaPayload.registry Not Saved/Restored`).
 
 ### IPFS-Loaded Strategy Model (`customs/`)
+
+**Scope caveat.** `customs/` and `FILE_HASH_TO_STRATEGIES` are **downstream service patterns** (e.g. `valory-xyz/trader`, `valory-xyz/optimus`) — they do NOT exist in `open-autonomy` itself. Audits scoped to the framework repo will produce vacuous "no findings" output for this section and for C3. Apply this subsection only when auditing a downstream service that adopts the pattern.
 
 Strategies under `customs/` (e.g. `kelly_criterion`, `fixed_bet`) are loaded by IPFS hash at runtime:
 
@@ -77,7 +82,7 @@ Strategies under `customs/` (e.g. `kelly_criterion`, `fixed_bet`) are loaded by 
 2. Code is fetched from IPFS, the content hash is verified against the configured hash, and the module is **executed in the agent process**.
 
 **Trust boundary:** the configured hash is the only thing standing between the agent and arbitrary code execution. The strategy code runs with full agent privileges:
-- Access to private keys via `KeyManager`
+- Access to private keys via the agent's `Wallet` / `CryptoStore` (`aea.crypto.wallet`)
 - Access to environment variables
 - Network access to all configured endpoints (RPC, exchange APIs, IPFS)
 - Ability to read/write `synchronized_data` (consensus-critical state)
@@ -110,6 +115,7 @@ Resolution happens at agent startup. Resolved values flow into `Params` / `Model
 Each agent ships with a Tendermint sidecar:
 - RPC port (default 26657) — used for ABCI queries, block info, broadcast
 - P2P port (default 26656) — peer-to-peer consensus
+- ABCI app socket (default 26658) — the port the agent's `abci` connection listens on (`packages/valory/connections/abci/connection.py:110` `DEFAULT_ABCI_PORT`); Tendermint dials in to deliver `CheckTx` / `DeliverTx` etc. A 0.0.0.0 bind here lets any peer drive the application directly, bypassing Tendermint
 - gRPC port (default 9090, optional)
 
 **Threat surface:**
@@ -164,7 +170,7 @@ The repo's `tox -e safety` allowlist already pins known-unfixed CVEs in transiti
 - `importlib.import_module(`, `__import__(` with non-literal arguments
 - `pickle.load`, `pickle.loads` on data not produced by the same trust boundary (file written by user, network response, IPFS payload)
 - `marshal.loads`, `shelve.open` on untrusted data
-- `yaml.load(` (without `Loader=SafeLoader`) — defaults to `FullLoader` which can construct arbitrary Python objects in older PyYAML versions
+- `yaml.load(...)` without `Loader=SafeLoader` — pre-5.4 `FullLoader` had **CVE-2020-14343** (arbitrary object construction); PyYAML ≥ 6.0 raises `TypeError` on missing `Loader`. Always pass `Loader=SafeLoader` (or `yaml.safe_load`) explicitly — even on PyYAML 6 — to be robust against future loader-default changes
 - `subprocess.*` with `shell=True` AND interpolated arguments (`f"cmd {var}"`, `"cmd " + var`, `cmd % var`)
 - `os.system(` with interpolated arguments
 - `Template(...).substitute(...)` where the template itself comes from untrusted input
@@ -183,12 +189,12 @@ def process_strategy(self, payload):
 
 #### C2: Private Key Disclosure
 
-**What:** Any code path that emits, persists, or returns a private key, mnemonic, seed, or signing material outside the `KeyManager` boundary.
+**What:** Any code path that emits, persists, or returns a private key, mnemonic, seed, or signing material outside the AEA crypto/wallet boundary (`aea.crypto.wallet.Wallet`, `Crypto.sign_message`, `CryptoStore`).
 
 **Search patterns:**
 - Variable name regex inside `logger.*`, `print(`, `return`, response builders, payload constructors:
   - `private_key`, `priv_key`, `pk`, `sk`, `secret`, `seed`, `mnemonic`, `entropy`, `signing_key`, `wallet.private_key`
-- HTTP handlers that read from `KeyManager` and return values in the response body (debug endpoints in particular)
+- HTTP handlers that read from the agent's `Wallet` / `CryptoStore` and return values in the response body (debug endpoints in particular)
 - Behaviours that interpolate signed material into `payload` fields broadcast over Tendermint
 - Files written by the agent that contain key material (`open(..., 'w')` with key in body)
 - Exception handlers that include the key in the error message (`raise ValueError(f"Bad key: {key}")`)
@@ -229,7 +235,7 @@ self.context.logger.info(f"Sent: {request}, Got: {response.json()}")
 - `marshal.loads(...)`
 - Custom deserializers that `eval` field values
 
-**Cross-reference:** audit-resilience BP14 covers `json.loads` exception handling at the connection boundary. /security-review C4 covers the harder issue: even if exception handling is correct, using a code-executing deserializer on network input is RCE waiting to happen.
+**Distinct from `audit-resilience` BP14.** BP14 audits whether the connection's `on_send` / `_route_request` catches `JSONDecodeError` from `json.loads(message.payload)` — i.e. a malformed-input robustness concern. C4 audits whether the deserializer itself is code-executing — i.e. an RCE concern. A connection can simultaneously have a BP14 finding (no exception handling) and a clean C4 (uses `json.loads`), or vice versa (uses `pickle.loads` inside a generous try-except → C4 finding without BP14). Different threat classes; report independently.
 
 **Fix:** use JSON; if a binary format is needed, use protobuf / msgpack with strict schemas.
 
@@ -243,7 +249,7 @@ self.context.logger.info(f"Sent: {request}, Got: {response.json()}")
 - Test fixtures that may have been accidentally promoted to runtime code paths
 
 **Search patterns** beyond gitleaks defaults. Gitleaks's built-in rules already cover common SaaS / cloud token shapes (Slack, GitHub, GitLab, AWS, Stripe, JWT, OpenAI, etc.) — do NOT re-list those literals here, listing them would re-trigger gitleaks on this file. Audit-specific additions:
-- `0x[a-fA-F0-9]{64}` (Ethereum private key shape) in non-test files
+- `0x[a-fA-F0-9]{64}` — 32-byte hex **shape** in non-test files. **High false-positive rate**: the same form matches Ethereum transaction hashes, block hashes, Keccak-256 outputs, storage-slot keys, IPFS CID v1 binary fields, and any `bytes32` literal. Triage before flagging: require proximity to a variable name in `{key, secret, mnemonic, pk, sk, private}`, OR exclude matches adjacent to `{tx_hash, block_hash, ipfs_hash, topic, slot}`. Without this triage, the rule fires on every block-hash literal in tests and tooling AND lets reviewers dismiss real keys as "just a hash"
 - `mnemonic = "..."`, mnemonic-shaped 12/15/18/21/24-word strings in source
 
 **Severity:** Critical regardless of intent — once committed, must be assumed compromised even after removal (git history retention).
@@ -337,25 +343,30 @@ def restart(agent_id: str):
 
 **Fix:** validate at `check_payload()` (round side) and at payload construction (behaviour side); use strict type hints (`Address`, `URL`, `PositiveInt`); reject out-of-range values.
 
-#### H6: Replay Protection Gaps
+#### H6: Replay Protection Gaps in Custom Rounds
 
-**What:** Round / payload designs that lack a per-period nonce and could be replayed across periods if the same agent re-submits a previously seen payload.
+**What:** Standard collection rounds inherit `process_payload()` from the framework, which verifies `payload.round_count == self.synchronized_data.round_count` (`packages/valory/skills/abstract_round_abci/base.py:1417`). H6 audits the narrower residual surface: **custom rounds that override `process_payload()` without invoking the parent check** (e.g. via `super().process_payload(payload)` or an equivalent `round_count` assertion).
 
 **How to check:**
-1. For each `payload_class`, list its fields. Is there a per-period nonce, period_count, or `last_round_transition_timestamp`?
-2. If not, can a payload from period N be re-submitted in period M with the same effect?
-3. For payloads that drive on-chain transactions, does the resulting tx include the chain-id, contract nonce, and Safe nonce?
+1. Grep for round subclasses that define their own `process_payload` (`def process_payload(self, payload`).
+2. For each, verify the override either:
+   - Calls `super().process_payload(payload)`, OR
+   - Performs an equivalent `if payload.round_count != self.synchronized_data.round_count: raise ...` check.
+3. If neither, this round's payloads from a closed period can be replayed in any later period — flag.
+4. For payloads that drive on-chain transactions, also verify the resulting tx includes chain-id, contract nonce, and Safe nonce (these are independent of the ABCI-level check).
 
-**Threat:** an attacker (or a buggy resubmission) replays a payload to trigger a duplicate financial action. (Cross-reference: audit-resilience BP15 covers idempotency on retry; H6 here is the consensus-level analogue.)
+**Threat:** an adversary captures a payload signed by a participant in period N and re-submits it in period M to re-trigger a state-changing action. Standard rounds reject this at `process_payload`; overriding rounds may not.
 
-**Fix:** include `period_count` or a per-round nonce in every payload that drives state-changing actions; verify on the round side.
+**Distinct from `audit-resilience` BP15.** BP15 protects against the same logical action being re-submitted via FSM retry / connection-layer retry (accidental, internal trigger). H6 protects against an old payload from a closed period being replayed on the consensus layer (adversarial, external trigger). Different attacker model, different mitigation surface — the mitigations partially overlap (idempotency on the action vs nonce/round_count on the payload) but require independent assessment.
+
+**Fix:** in every custom `process_payload` override, either call `super().process_payload(payload)` first, or replicate the `round_count` check explicitly.
 
 #### H7: Dependency CVEs
 
-**What:** Run `tox -e safety` (which uses tomte's allowlist) and `pip-audit` against the resolved environment. Each unaddressed CVE in a runtime dep is a finding.
+**What:** Run `tox -e safety` (which uses tomte's allowlist) against the resolved environment. Each unaddressed CVE in a runtime dep is a finding. `pip-audit` is optional second-source coverage but is **NOT pre-configured** in this repo — there is no `[testenv:pip-audit]` stanza in `tox.ini` and `make security` runs only `safety`, `bandit`, and `gitleaks`. If you want pip-audit cross-check, install it manually (`pip install pip-audit`) and run separately; note in the report.
 
 **Process:**
-1. Run `tox -e safety` and `pip-audit -r <lockfile>` (or directly against the venv).
+1. Run `tox -e safety`. Optionally `pip install pip-audit && pip-audit -r <lockfile>` for second-source coverage.
 2. For each CVE not in the allowlist, document: package, version, CVE ID, severity per upstream, exploitability in this codebase (does the agent reach the vulnerable code path?).
 3. Audit the existing tomte allowlist (`-i 37524 -i 38038 ...` in `tox.ini`) — for each pinned CVE, check whether upstream has shipped a fix that allows the pin to be removed.
 
@@ -451,14 +462,7 @@ def restart(agent_id: str):
 
 #### L1: Missing Secrets-in-Logs Redaction Policy
 
-**What:** Audit-fsm L4 covers individual log-line leaks. /security-review L1 escalates to the systemic level: is there a redaction layer in the logging pipeline, or does every author bear the burden individually?
-
-**How to check:**
-- Look for a centralized log filter / formatter that redacts secret-shaped strings
-- Check whether `logging.config.dictConfig(...)` includes a `RedactingFormatter` or similar
-- Check whether sensitive fields are dropped at the structured-log boundary (e.g. via `structlog` processors)
-
-**Fix:** add a redacting formatter that masks Ethereum-key-shaped strings, JWTs, Bearer tokens, and any field name in a configurable allowlist.
+C2 covers individual-call-site disclosure. L1 asks the systemic question: is there a redaction layer in the logging pipeline (formatter / `structlog` processor / `logging.config.dictConfig` filter) that masks secret-shaped values, or does every author bear the burden individually? If the latter, file as L1 — defense-in-depth gap.
 
 #### L2: No Startup-Time Secret-Validation Check
 
@@ -518,33 +522,28 @@ Contract addresses are public on-chain. They are not secrets. Don't conflate wit
 
 ## Methodology Guardrails
 
-These guardrails reduce false positives observed in prior audit runs.
+Two sets of guardrails apply: the **cross-skill** ones already documented in `/audit-fsm` and `/audit-resilience`, and the **security-specific** ones below.
+
+**Apply the cross-skill guardrails from the sibling Methodology Guardrails sections without restating them here:**
+- *Verify every sub-agent finding before accepting it* — read source, confirm severity, consolidate splits, demote liberally.
+- *Force the data-type trace before flagging* — runtime type ≠ static annotation when JSON crosses the boundary.
+- *Single-finding-per-bug* — one root cause = one report entry citing all relevant IDs.
+
+These reduce duplication and prevent drift when the sibling skills evolve. Below are the guardrails that are genuinely specific to security review.
 
 ### Distinguish disclosure from exposure
 - **Disclosure** = the secret has left the trust boundary (in a log, response, payload, file outside the agent dir).
-- **Exposure** = the secret is reachable via a code path but not yet emitted (e.g. `KeyManager.get_key()` is callable from a behaviour).
+- **Exposure** = the secret is reachable via a code path but not yet emitted (e.g. `Wallet.crypto_objects[<ledger>].entity` / `.private_key` is callable from a behaviour).
 
 C2 is for disclosure. Exposure is M-level at most, often L (defense in depth). Don't over-escalate exposure to Critical.
 
 ### Trace every "untrusted input" claim to a source
 For C1, C4, C6, M3 findings: name the **source** of the untrusted input (HTTP request body, ABCI payload field, env var, file content, IPFS payload). If you can't name it, downgrade or drop the finding.
 
-### Test code is in scope but with reduced severity
-Test files can leak secrets that get history-mirrored, can introduce supply-chain risks via test deps, and can mask production bugs. Audit them. But:
-- Hardcoded test keys: not a finding (see False Positive Guidance).
-- Dev-only deps: not a finding unless the dep is also imported in non-test code (`grep` to verify).
-- `eval` in test scaffolding: not a finding unless the eval input comes from a non-test surface.
-
-### Dual-skill findings
-If a finding fits audit-fsm or audit-resilience better, cite that skill's check ID and demote here. Examples:
-- "logger.info(f'key={k}')" → cite audit-fsm L4 first; /security-review C2 only adds the disclosure framing.
-- "no timeout on HTTP" → audit-resilience BP8/CC5 owns this; /security-review only flags if the timeout absence enables a security-relevant DOS or resource exhaustion.
-
-### Single-finding-per-bug
-If multiple checks (e.g. C1 RCE + H7 outdated dep + M4 weak crypto) flag the same root cause, report once with all relevant IDs cited.
-
-### Don't trust the static type
-Mirror of audit-fsm/audit-resilience methodology: fields annotated as `str` may be deserialized JSON whose runtime type differs. Trace the source before claiming a type-based safety property.
+### Dual-skill findings — cite the owning skill, demote here
+If a finding fits `/audit-fsm` or `/audit-resilience` better, cite that skill's check ID as the primary and demote here. Examples:
+- `logger.info(f'key={k}')` → cite `audit-fsm` L4 first; /security-review C2 adds only the disclosure framing.
+- `requests.get(...)` with no timeout → `audit-resilience` BP8 / CC5 owns this; /security-review flags only if the missing timeout enables a security-relevant DoS or resource-exhaustion attack on a trust boundary.
 
 ---
 
@@ -638,7 +637,7 @@ Present the security review as follows:
 
 **Scope:** [list of audited paths / packages / services]
 **Date:** [current date]
-**Tools run:** bandit (Y/N), safety (Y/N), gitleaks (Y/N), pip-audit (Y/N)
+**Tools run:** bandit (Y/N), safety (Y/N), gitleaks (Y/N), pip-audit (Y/N — optional second-source; install manually)
 
 ## Executive Summary
 
@@ -679,7 +678,7 @@ Present the security review as follows:
 
 | Secret | Storage | Loaded by | Rotation policy |
 |---|---|---|---|
-| Ethereum private key | mounted volume | KeyManager | manual |
+| Ethereum private key | mounted volume | `aea.crypto.wallet.Wallet` | manual |
 | ... |
 
 ## Trust Boundaries
@@ -710,15 +709,6 @@ Present the security review as follows:
 [hits, by file]
 
 ---
-
-## Summary
-
-| Severity | Count |
-|----------|-------|
-| Critical | N     |
-| High     | N     |
-| Medium   | N     |
-| Low      | N     |
 
 ## What This Audit Did Not Cover
 


### PR DESCRIPTION
Closes #2495.

Extends both audit skills with the gaps documented in #2495 from real audit runs against `valory-xyz/trader`, `valory-xyz/optimus`, and `valory-xyz/meme-ooorr`.

## Summary

### `audit-fsm`
- **C5** non-determinism in `end_block()` (file I/O, `time.time`, `random.*`, `os.environ`, network)
- **M6** `SynchronizedData` JSON round-trip safety + MRO shadowing across composed data classes
- **M7** `cross_period_persisted_keys` completeness for post-reset initial-round reads
- **M8** misleading `Event`-valued class attributes on `CollectSameUntilThresholdRound` subclasses
- **L4** logging hygiene (secret / PII leakage)
- **L5** numeric precision in financial logic
- **C3** carve-out for framework-scheduled events (`ROUND_TIMEOUT` from `event_to_timeout`) — fixes the meme-ooorr false positive
- Scope extensions for `customs/` strategies (when `FILE_HASH_TO_STRATEGIES` is set) and `services/*/service.yaml` overrides
- Methodology guardrails: data-type trace before flagging type mismatches
- `is_abstract: true` semantics; library-skill list now marked as project-specific
- CLI-tool-unavailable handling in Step 0 (do not report missing library skills as a finding)
- Coverage Limitations + report-template "what this audit did not cover"

### `audit-resilience`
- **BP15** idempotency on retry of financial actions — the highest-leverage gap
- **BP16** stringified-exception retry conditions (`if "rate limit" in str(e)`)
- **BP17** defined-but-unenforced security allowlists
- **BP18** inverted fail-safe on unknown state (RPC down → optimistic default)
- **BP19** `verify=False` / hardcoded credentials / secrets in URL query strings
- **BP20** pagination partial-failure semantics
- **BP21** response size bounds
- **BP22** clock-window-signed requests (intersects with FSM determinism)
- **CC8** worst-case blocking vs `round_timeout` (orphaned thread pattern)
- **CC9** per-call-site observability table
- `services/*/service.yaml` override coverage
- Methodology guardrails: data-type trace + verbatim BP1 pre-flag reminder (the `JSONDecodeError`-vs-`ValueError` false positive)
- Coverage Limitations + report-template observability table, override findings, and "what this audit did not cover"

Two issue items deferred deliberately: audit-fsm gap #4 (payload-class git-history diffing — not statically derivable) and #5 (cross-skill import classification — partial coverage exists via existing checks). Everything else from the issue body and the optimus / meme-ooorr follow-up comments is wired in.

## Test plan

- [ ] Re-run `/audit-fsm` against `valory-xyz/trader` and confirm the C5 / M6-M8 / L4-L5 findings surface
- [ ] Re-run `/audit-resilience` against `valory-xyz/trader` and confirm BP15 (idempotency) is now flagged
- [ ] Re-run `/audit-fsm` against `valory-xyz/meme-ooorr` and confirm `ROUND_TIMEOUT`-on-`end_block` false positive is gone
- [ ] Re-run `/audit-resilience` against `valory-xyz/optimus` and confirm `JSONDecodeError`-on-`except ValueError` false positives are gone
- [ ] Both reports include a "What this audit did not cover" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
