### PR TITLE
chore: bump idna to 3.17 (GHSA-65pc-fj4g-8rjx)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2316,14 +2316,14 @@ zoneinfo = ["tzdata (>=2026.1)"]
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.17"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"},
-    {file = "idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242"},
+    {file = "idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"},
+    {file = "idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## What

Bumps the transitive `idna` dependency from **3.13 → 3.17** in `poetry.lock` to resolve the ReDoS advisory in `idna.encode()`.

- Closes #2529
- Advisory: GHSA-65pc-fj4g-8rjx (severity **medium**), vulnerable range `< 3.15`, fixed in `3.15` (3.17 is the latest patched line).

## Scope

`idna` is a pure transitive leaf dependency (no constraint in `pyproject.toml`, no dependencies of its own). This is a **lock-only** change: a single `[[package]]` block updated (version, `python-versions`, file hashes). The pyproject `content-hash` is unchanged.

## Verification (local)

- `poetry check --lock` → exit 0 (lock consistent with pyproject) ✅
- `poetry.lock` parses as valid TOML; idna resolves to 3.17 ✅
- idna 3.17 hashes verified against PyPI ✅

Per the targeted-verification approach for this repo's large CI, the full `main_workflow.yml` matrix (hash/dependency/security checks + test suite) runs here in CI. No `packages/` or source files were touched, so package-hash and API-doc checks are unaffected.