### PR TITLE
fix(chain): preserve last error when TxSettler exhausts retries

### DIFF
--- a/autonomy/chain/tx.py
+++ b/autonomy/chain/tx.py
@@ -194,6 +194,7 @@ class TxSettler:  # pylint: disable=too-many-instance-attributes
         """Make a transaction and return a receipt"""
         retries = 0
         deadline = datetime.now().timestamp() + self.timeout
+        last_error: Optional[Exception] = None
         while retries < self.retries and deadline >= datetime.now().timestamp():
             retries += 1
             try:
@@ -215,6 +216,7 @@ class TxSettler:  # pylint: disable=too-many-instance-attributes
             except get_requests_connection_error() as e:
                 raise RPCError("Cannot connect to the given RPC") from e
             except Exception as e:  # pylint: disable=broad-except
+                last_error = e
                 error = str(e)
                 if not should_retry(error):
                     raise ChainInteractionError(error) from e
@@ -239,9 +241,10 @@ class TxSettler:  # pylint: disable=too-many-instance-attributes
                 )
                 time.sleep(self.sleep)
 
-        raise ChainTimeoutError(
-            f"Failed to send transaction after {self.retries} retries"
-        )
+        message = f"Failed to send transaction after {self.retries} retries"
+        if last_error is not None:
+            message = f"{message}: {last_error}"
+        raise ChainTimeoutError(message) from last_error
 
     def settle(self) -> "TxSettler":
         """Wait for the tx to be mined."""

--- a/autonomy/cli/helpers/docstring.py
+++ b/autonomy/cli/helpers/docstring.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2022-2025 Valory AG
+#   Copyright 2022-2026 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tests/test_autonomy/test_chain/test_tx.py
+++ b/tests/test_autonomy/test_chain/test_tx.py
@@ -281,6 +281,48 @@ def test_timeout() -> None:
         settler.transact()
 
 
+def test_timeout_preserves_last_error() -> None:
+    """Timeout should carry the last underlying error so callers can classify it."""
+
+    underlying = (
+        "{'code': -32000, 'message': "
+        "'intrinsic gas too low: gas 0, minimum needed 24796'}"
+    )
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        raise Exception(underlying)
+
+    settler = TxSettler(
+        ledger_api=mock.Mock(
+            send_signed_transaction=_raise,
+            try_get_gas_pricing=lambda **kwargs: {
+                "maxFeePerGas": 100,
+                "maxPriorityFeePerGas": 100,
+            },
+            update_with_gas_estimate=lambda tx: tx,
+        ),
+        crypto=mock.Mock(
+            sign_transaction=lambda transaction: transaction,
+        ),
+        chain_type=ChainType.LOCAL,
+        tx_builder=lambda: {},
+        retries=2,
+        sleep=0.01,
+    )
+
+    with mock.patch("autonomy.chain.tx.time.sleep"):
+        with pytest.raises(ChainTimeoutError) as exc_info:
+            settler.transact()
+
+    raised = exc_info.value
+    assert "Failed to send transaction after 2 retries" in str(raised)
+    # The retryable -32000 rejection that drove every retry must survive in the
+    # message and as the exception cause, instead of being dropped.
+    assert underlying in str(raised)
+    assert raised.__cause__ is not None
+    assert str(raised.__cause__) == underlying
+
+
 @mock.patch("autonomy.chain.tx.logger")
 def test_settle_waits_until_rpc_syncs(logger: mock.Mock) -> None:
     """Test settler loops until RPC catches up with receipt block."""


### PR DESCRIPTION
## Problem

When `TxSettler.transact()` exhausts its retry/timeout budget, it raises:

```
ChainTimeoutError("Failed to send transaction after {retries} retries")
```

This drops the **underlying RPC error that drove every retry**. Callers that classify failures by inspecting the error string cannot see the cause, so a diagnosable failure (e.g. an insufficient-gas / insufficient-funds RPC rejection that was repriced on every attempt) surfaces as an opaque timeout.

### Concrete impact

A downstream consumer maps gas/funds RPC rejections to a typed *insufficient-funds* error by matching the RPC error string. When the same condition happens to return a **non-retryable** wording, it propagates via `ChainInteractionError` (carrying the original RPC payload) and is classified correctly. But when every attempt returns a **retryable** wording (e.g. `intrinsic gas too low: gas 0` → reprice), the loop runs to exhaustion and raises the bare `ChainTimeoutError`, whose message contains none of the original error — so the same root cause is misclassified and returned as a generic 500 instead of a typed 4xx.

## Fix

- Capture the last caught exception in `last_error` inside the retry loop.
- On retry/timeout exhaustion, append it to the `ChainTimeoutError` message and chain it as the cause (`raise ChainTimeoutError(message) from last_error`).

Before:
```
Failed to send transaction after 60 retries
```
After:
```
Failed to send transaction after 60 retries: {'code': -32000, 'message': 'intrinsic gas too low: gas 0, minimum needed 24796'}
```
…with `__cause__` set for a full traceback.

The success path, signature, and return type are unchanged. The existing `test_same_tx_sent_twice` assertion uses `re.search` on the prefix, which the appended suffix preserves.

## Tests

- Added `test_timeout_preserves_last_error`: drives the reprice→exhaustion path and asserts the timeout message includes the underlying error and that `__cause__` is set.

## Linters

black ✓ · isort ✓ · flake8 ✓ · darglint ✓ · mypy (`autonomy/chain/tx.py`) ✓ — no new issues introduced.