### PR TITLE
fix(multisend): coerce web3-7 HexStr call data to bytes in encode_data

### DIFF
--- a/packages/valory/contracts/multisend/contract.py
+++ b/packages/valory/contracts/multisend/contract.py
@@ -56,7 +56,12 @@ def encode_data(tx: Dict) -> bytes:
     value = bytes.fromhex(
         "{:0>64x}".format(cast(int, tx.get("value")))
     )  # Value 32 bytes
-    data = cast(bytes, tx.get("data", b""))
+    data = tx.get("data", b"")
+    if isinstance(data, str):
+        # web3 v7 returns call data as a 0x-prefixed HexStr; coerce to bytes
+        # so the concatenation below does not raise ``can't concat str to bytes``.
+        data = bytes.fromhex(data[2:] if data.startswith("0x") else data)
+    data = cast(bytes, data)
     data_length = bytes.fromhex("{:0>64x}".format(len(data)))  # Data length 32 bytes
     return operation + to + value + data_length + data
 


### PR DESCRIPTION
## Problem
`valory/multisend` `encode_data` does:
```python
data = cast(bytes, tx.get("data", b""))
...
return operation + to + value + data_length + data
```
The framework targets **web3 v7** (`web3>=7,<8`), and web3 v7 returns call data as a **`HexStr` (str)**. `cast` is a no-op, so when `data` is a str the final concatenation raises:
```
TypeError: can't concat str to bytes
```
This breaks **any** multisend-based flow on web3 7 — notably on-chain **service minting** (it builds the mint/activate/register/deploy calls into a multisend). Reproduced via `mech-server`'s `mech setup` (open-autonomy 0.21.23+): the mint fails at `multisend.get_tx_data` → `encode_data`.

## Fix
Coerce a `str` `data` (0x-prefixed or bare hex) to `bytes` before concatenation; `bytes`/`HexBytes` input is unchanged. Applied to `packages/valory/contracts/multisend/contract.py` (the `autonomy/data/` bundled copy is git-ignored and regenerated from `packages/`).

## ⚠️ Draft — package hashes not regenerated
This changes a content-addressed package, so it needs `make generators` + `autonomy packages lock` (and the resulting cascade across dependents + `packages.json`). I couldn't run that safely here (local `autonomy` CLI is 0.21.18 vs repo 0.21.24, and the dev env isn't set up), so CI `check-hash`/`check-packages` will be red until a maintainer re-locks in the proper env. Marking draft for that reason — the code change itself is complete and lint/copyright-clean.